### PR TITLE
chore: add release profile and required element needed for release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
-            <version>3.7.7</version>
+            <version>${version.mockito}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,6 +6,56 @@
     <artifactId>buildpack-client</artifactId>
     <version>0.0.2-SNAPSHOT</version>
 
+    <url>https://snowdrop.dev</url>
+    <inceptionYear>2020</inceptionYear>
+
+    <organization>
+      <name>Red Hat</name>
+      <url>http://redhat.com</url>
+    </organization>
+
+    <licenses>
+      <license>
+        <name>Apache License, Version 2.0</name>
+        <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        <distribution>repo</distribution>
+      </license>
+    </licenses>
+
+    <!-- including A developer as it's required by the maven poms going into central -->
+    <developers>
+      <developer>
+        <id>geeks</id>
+        <name>Snowdrop Development Team</name>
+        <organization>snowdrop</organization>
+        <organizationUrl>http://snowdrop.dev/</organizationUrl>
+      </developer>
+    </developers>
+
+    <scm>
+      <connection>scm:git:git@github.com:snowdrop/java-buildpack-client.git</connection>
+      <developerConnection>scm:git:git@github.com:snowdrop/java-buildpack-client.git</developerConnection>
+      <url>http://github.com/snowdrop/java-buildpack-client</url>
+      <tag>${project.version}</tag>
+    </scm>
+
+    <distributionManagement>
+      <repository>
+        <id>oss-sonatype-staging</id>
+        <name>Sonatype Staging Repository</name>
+        <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+      </repository>
+    </distributionManagement>
+
+
+    <properties>
+      <!-- Release Plugins -->
+      <version.maven-gpg-plugin>1.6</version.maven-gpg-plugin>
+      <version.maven-enforcer-plugin>1.3.1</version.maven-enforcer-plugin>
+      <version.maven-javadoc-plugin>2.10.3</version.maven-javadoc-plugin>
+      <version.maven-source-plugin>2.4</version.maven-source-plugin>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.github.docker-java</groupId>
@@ -73,37 +123,122 @@
     </dependencies>
 
     <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <release>11</release>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.0</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.0</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-				<version>3.2.1</version>
-				<executions>
-					<execution>
-						<id>attach-sources</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-					</execution>
-				</executions>
-            </plugin>
-        </plugins>
+      <plugins>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.1</version>
+          <configuration>
+            <release>11</release>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.22.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <version>2.22.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+	  <version>${version.maven-source-plugin}</version>
+	  <executions>
+	    <execution>
+	      <id>attach-sources</id>
+	      <goals>
+		<goal>jar</goal>
+	      </goals>
+	    </execution>
+	  </executions>
+        </plugin>
+      </plugins>
     </build>
+
+  <profiles>
+    <profile>
+      <id>release</id>
+      <properties>
+        <skipITs>true</skipITs>
+        <format.skip>true</format.skip>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>${version.maven-gpg-plugin}</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <version>${version.maven-enforcer-plugin}</version>
+            <executions>
+              <execution>
+                <id>enforce-no-snapshots</id>
+                <goals>
+                  <goal>enforce</goal>
+                </goals>
+                <configuration>
+                  <rules>
+                    <requireReleaseDeps>
+                      <message>No Snapshots Allowed!</message>
+                    </requireReleaseDeps>
+                  </rules>
+                  <fail>false</fail>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>${version.maven-javadoc-plugin}</version>
+            <configuration>
+              <includeDependencySources>${javadoc.include.deps}</includeDependencySources>
+              <dependencySourceIncludes>
+                <dependencySourceInclude>${javadoc.source.includes}</dependencySourceInclude>
+              </dependencySourceIncludes>
+              <excludePackageNames>${javadoc.package.excludes}</excludePackageNames>
+            </configuration>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+                <configuration>
+                  <additionalparam>${javadoc.opts}</additionalparam>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>${version.maven-source-plugin}</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,21 @@
 
 
     <properties>
+      <!-- Dependency Versions -->
+      <version.docker-java>3.2.7</version.docker-java>
+      <version.slf4j>1.7.30</version.slf4j>
+      <version.commons-compress>1.20</version.commons-compress>
+      <version.jackson>2.10.3</version.jackson>
+      <version.lombok>1.18.12</version.lombok>
+      <version.findbugs>3.0.1u2</version.findbugs>
+      <version.junit>5.4.0</version.junit>
+      <version.mockito>3.7.7</version.mockito>
+
+      <!-- Maven Plugin Versions -->
+      <version.maven-compiler-plugin>3.8.1</version.maven-compiler-plugin>
+      <version.maven-surefire-plugin>2.22.0</version.maven-surefire-plugin>
+      <version.maven-failsafe-plugin>2.22.0</version.maven-failsafe-plugin>
+
       <!-- Release Plugins -->
       <version.maven-gpg-plugin>1.6</version.maven-gpg-plugin>
       <version.maven-enforcer-plugin>1.3.1</version.maven-enforcer-plugin>
@@ -60,51 +75,51 @@
         <dependency>
             <groupId>com.github.docker-java</groupId>
             <artifactId>docker-java-core</artifactId>
-            <version>3.2.7</version>
+            <version>${version.docker-java}</version>
         </dependency>
         <dependency>
             <groupId>com.github.docker-java</groupId>
             <artifactId>docker-java-transport-httpclient5</artifactId>
-            <version>3.2.7</version>
+            <version>${version.docker-java}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.7.30</version>
+            <version>${version.slf4j}</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.20</version>
+            <version>${version.commons-compress}</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.12</version>
+            <version>${version.lombok}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.10.3</version>
+            <version>${version.jackson}</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>annotations</artifactId>
-            <version>3.0.1u2</version>
+            <version>${version.findbugs}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.4.0</version>
+            <version>${version.junit}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.4.0</version>
+            <version>${version.junit}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -116,7 +131,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>3.8.0</version>
+            <version>${version.mockito}</version>
             <scope>test</scope>
         </dependency>
 
@@ -126,7 +141,7 @@
       <plugins>
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.1</version>
+          <version>${version.maven-compiler-plugin}</version>
           <configuration>
             <release>11</release>
           </configuration>
@@ -134,12 +149,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.22.0</version>
+          <version>${version.maven-surefire-plugin}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>2.22.0</version>
+          <version>${version.maven-failsafe-plugin}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
       <version.docker-java>3.2.7</version.docker-java>
       <version.slf4j>1.7.30</version.slf4j>
       <version.commons-compress>1.20</version.commons-compress>
-      <version.jackson>2.10.3</version.jackson>
+      <version.jackson>2.12.3</version.jackson>
       <version.lombok>1.18.12</version.lombok>
       <version.findbugs>3.0.1u2</version.findbugs>
       <version.junit>5.4.0</version.junit>


### PR DESCRIPTION
The pull request changes the following:

- prepare the pom for sonatype release (add required elemenets and release profile)
- externalize versions to properties
- align mockito versions
- bump jackson to align with the rest of the ecosystem (sb, dekorate etc).