### PR TITLE
Add support for java 8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [11]
+        java: [8, 11]
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,0 @@
-jdk:
- - openjdk11

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,8 @@
 
 
     <properties>
+      <java.source>1.8</java.source>
+      <java.target>1.8</java.target>
       <!-- Dependency Versions -->
       <version.docker-java>3.2.7</version.docker-java>
       <version.slf4j>1.7.30</version.slf4j>
@@ -134,21 +136,17 @@
             <version>${version.mockito}</version>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>2.6</version>
-        </dependency>
     </dependencies>
 
     <build>
       <plugins>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${version.maven-compiler-plugin}</version>
           <configuration>
-            <release>11</release>
+            <source>${java.source}</source>
+            <target>${java.target}</target>
           </configuration>
         </plugin>
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,11 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.6</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/dev/snowdrop/buildpack/docker/ContainerUtils.java
+++ b/src/main/java/dev/snowdrop/buildpack/docker/ContainerUtils.java
@@ -24,6 +24,8 @@ import com.github.dockerjava.api.command.CreateContainerResponse;
 import com.github.dockerjava.api.model.Bind;
 import com.github.dockerjava.api.model.Volume;
 
+import org.apache.commons.io.IOUtils;
+
 import dev.snowdrop.buildpack.docker.ContainerEntry.ContentSupplier;
 
 public class ContainerUtils {
@@ -172,7 +174,9 @@ public class ContainerUtils {
                 if(is==null) {
                   throw new IOException("Error ContentSupplier gave null for getData");
                 }
-                is.transferTo(tout);
+                
+                IOUtils.copy(is, tout);
+                
               }
               tout.closeArchiveEntry();
             }

--- a/src/main/java/dev/snowdrop/buildpack/docker/ContainerUtils.java
+++ b/src/main/java/dev/snowdrop/buildpack/docker/ContainerUtils.java
@@ -4,6 +4,7 @@ import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.util.ArrayList;
@@ -23,8 +24,6 @@ import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.command.CreateContainerResponse;
 import com.github.dockerjava.api.model.Bind;
 import com.github.dockerjava.api.model.Volume;
-
-import org.apache.commons.io.IOUtils;
 
 import dev.snowdrop.buildpack.docker.ContainerEntry.ContentSupplier;
 
@@ -175,7 +174,7 @@ public class ContainerUtils {
                   throw new IOException("Error ContentSupplier gave null for getData");
                 }
                 
-                IOUtils.copy(is, tout);
+                copy(is, tout);
                 
               }
               tout.closeArchiveEntry();
@@ -211,6 +210,14 @@ public class ContainerUtils {
       if (wio != null) {
         throw wio;
       }
+    }
+  }
+
+  private static final void copy(InputStream in, OutputStream out) throws IOException {
+    byte[] buf = new byte[8192];
+    int length;
+      while ((length = in.read(buf)) > 0) {
+        out.write(buf, 0, length);
     }
   }
 }


### PR DESCRIPTION
This is an alternative to #14 that squashes @fatiiates commits in 1 and adds some additional things:
- removal of commons-io
- enable java8 in github actions 