### PR TITLE
refactor: intro/use BuildpackException over checked Exceptions

### DIFF
--- a/client/src/main/java/dev/snowdrop/buildpack/BuildpackBuilder.java
+++ b/client/src/main/java/dev/snowdrop/buildpack/BuildpackBuilder.java
@@ -34,11 +34,11 @@ public interface BuildpackBuilder {
     BuildpackBuilder useDockerDaemon(boolean useDaemon);    
 
     //application content specification
-    BuildpackBuilder withContent(File content) throws Exception;    
-    BuildpackBuilder withContent(String prefix, File content) throws Exception;
+    BuildpackBuilder withContent(File content);    
+    BuildpackBuilder withContent(String prefix, File content);
     BuildpackBuilder withContent(String filepath, String filecontent);
-    BuildpackBuilder withContent(String filepath, long length, ContentSupplier content) throws Exception;
-    BuildpackBuilder withContent(ContainerEntry... entries) throws Exception;
+    BuildpackBuilder withContent(String filepath, long length, ContentSupplier content);
+    BuildpackBuilder withContent(ContainerEntry... entries);
 
     //build cache configuration
     BuildpackBuilder withBuildCache(String cacheVolume);
@@ -53,8 +53,8 @@ public interface BuildpackBuilder {
     BuildpackBuilder requestBuildTimestamps(boolean timestampsEnabled);
 
     //execute build
-    int build() throws Exception;
-    int build(LogReader logger) throws Exception;
+    int build();
+    int build(LogReader logger);
 
     //handle messages during build
     static interface LogReader {

--- a/client/src/main/java/dev/snowdrop/buildpack/BuildpackException.java
+++ b/client/src/main/java/dev/snowdrop/buildpack/BuildpackException.java
@@ -1,0 +1,30 @@
+package dev.snowdrop.buildpack;
+
+public class BuildpackException extends RuntimeException {
+
+  public BuildpackException() {
+  }
+
+  public BuildpackException(Throwable cause) {
+    super(cause);
+  }
+
+  public BuildpackException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public static RuntimeException launderThrowable(Throwable cause) {
+    return launderThrowable(cause.getMessage(), cause);
+  }
+
+  public static RuntimeException launderThrowable(String message, Throwable cause) {
+    if (cause instanceof RuntimeException) {
+      return ((RuntimeException) cause);
+    } else if (cause instanceof Error) {
+      throw ((Error) cause);
+    } else if (cause instanceof InterruptedException) {
+      Thread.currentThread().interrupt();
+    }
+    return new BuildpackException(message, cause);
+  }
+}

--- a/client/src/main/java/dev/snowdrop/buildpack/docker/ImageUtils.java
+++ b/client/src/main/java/dev/snowdrop/buildpack/docker/ImageUtils.java
@@ -15,7 +15,8 @@ import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.InspectImageResponse;
 import com.github.dockerjava.api.command.PullImageResultCallback;
 import com.github.dockerjava.api.model.Image;
-
+  
+import dev.snowdrop.buildpack.BuildpackException;
 /**
  * Higher level docker image api
  */
@@ -31,7 +32,7 @@ public class ImageUtils {
   /**
    * Util method to pull images if they don't exist to the local docker yet.
    */
-  public static void pullImages(DockerClient dc, int timeoutSeconds, String... imageNames) throws InterruptedException {
+  public static void pullImages(DockerClient dc, int timeoutSeconds, String... imageNames) {
     Set<String> imageNameSet = new HashSet<>(Arrays.asList(imageNames));
 
     // list the current known images
@@ -64,7 +65,11 @@ public class ImageUtils {
 
     // wait for pulls to complete.
     for (PullImageResultCallback pirc : pircs) {
-      pirc.awaitCompletion(timeoutSeconds, TimeUnit.SECONDS);
+      try {
+        pirc.awaitCompletion(timeoutSeconds, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+        throw BuildpackException.launderThrowable(e);
+      }
     }
 
     // TODO: progress tracking..

--- a/client/src/main/java/dev/snowdrop/buildpack/docker/VolumeUtils.java
+++ b/client/src/main/java/dev/snowdrop/buildpack/docker/VolumeUtils.java
@@ -29,13 +29,11 @@ public class VolumeUtils {
     dc.removeVolumeCmd(volumeName).exec();
   }
 
-  public static boolean addContentToVolume(DockerClient dc, String volumeName, String pathInVolume, File content)
-      throws IOException {
+  public static boolean addContentToVolume(DockerClient dc, String volumeName, String pathInVolume, File content) {
     return internalAddContentToVolume(dc, volumeName, ContainerEntry.fromFile("/volumecontent", content));
   }
 
-  public static boolean addContentToVolume(DockerClient dc, String volumeName, String name, String content)
-      throws IOException {
+  public static boolean addContentToVolume(DockerClient dc, String volumeName, String name, String content) {
     return internalAddContentToVolume(dc, volumeName, ContainerEntry.fromString("/volumecontent/" + name, content));
   }
 
@@ -44,8 +42,7 @@ public class VolumeUtils {
     return exists(dc, volumeName);
   }
 
-  private static boolean internalAddContentToVolume(DockerClient dc, String volumeName, ContainerEntry... entries)
-      throws IOException {
+  private static boolean internalAddContentToVolume(DockerClient dc, String volumeName, ContainerEntry... entries) {
     // TODO: find better 'no-op' container to use?
     String dummyId = ContainerUtils.createContainer(dc, "tianon/true", new VolumeBind(volumeName, "/volumecontent"));
 

--- a/samples/hello-spring/pack.java
+++ b/samples/hello-spring/pack.java
@@ -1,7 +1,7 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
 // //DEPS <dependency1> <dependency2>
 
-//DEPS dev.snowdrop:buildpack-client:0.0.2
+//DEPS dev.snowdrop:buildpack-client:0.0.3-SNAPSHOT
 import static java.lang.System.*;
 
 import java.io.File;
@@ -10,13 +10,9 @@ import dev.snowdrop.buildpack.*;
 public class pack {
 
     public static void main(String... args) {
-      try {
       BuildpackBuilder.get()
         .withContent(new File("."))
         .withFinalImage("snowdrop/hello-spring:latest")
         .build(new LogRelay());
-      } catch (Exception e) {
-        e.printStackTrace();
-      }
     }
 }


### PR DESCRIPTION
The pull request removes checked Exceptions and introduces BuildpackException as a way to launder checked Exceptions and Throwables.