### PR TITLE
Remove uneeded deps

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -27,11 +27,6 @@
             <artifactId>docker-java-transport-httpclient5</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
         </dependency>
@@ -39,20 +34,17 @@
           <groupId>io.sundr</groupId>
           <artifactId>builder-annotations</artifactId>
           <scope>compile</scope>
+          <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>annotations</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -94,12 +94,12 @@
         <groupId>com.github.docker-java</groupId>
         <artifactId>docker-java-transport-httpclient5</artifactId>
         <version>${version.docker-java}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-simple</artifactId>
-        <version>${version.slf4j}</version>
-        <scope>runtime</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>org.checkerframework</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>

--- a/release.sh
+++ b/release.sh
@@ -9,12 +9,11 @@ source $(grab github.com/shellib/cli)
 source $(grab github.com/shellib/maven as maven)
 
 release_version=$(readopt --release-version $*)
+dev_version=$(readopt --dev-version $*)
 if [ -z $release_version ]; then
   echo "Option --release_version is required!"
   exit 1
 fi
-
-maven::release $*
 
 #
 # Set release version in the samples & readme
@@ -26,4 +25,19 @@ done
 sed -i "s/\/\/DEPS dev.snowdrop:buildpack-client:.*/\/\/DEPS dev.snowdrop:buildpack-client:${release_version}/g" README.md
 sed -i "s/<version>.*<\/version>/<version>${release_version}<\/version>/g" README.md
 git add README.md
-git commit -m "chore: set release version in samples and README.md"
+git commit -m "chore: set release version: ${release_version} in samples and README.md"
+
+#
+# release
+#
+
+maven::release $*
+
+#
+# Set dev-release version in the samples (needed for CI)
+#
+find ./samples/ -iwholename "*/pack.java" | while read f; do
+    sed -i "s/\/\/DEPS dev.snowdrop:buildpack-client:.*/\/\/DEPS dev.snowdrop:buildpack-client:${dev_version}/g" $f
+    git add $f
+done
+git commit -m "chore: set dev version: ${dev_version} in samples and README.md"

--- a/samples/hello-spring/pack.java
+++ b/samples/hello-spring/pack.java
@@ -1,6 +1,6 @@
 ///usr/bin/env jbang "$0" "$@" ; exit $?
 
-//DEPS dev.snowdrop:buildpack-client:0.0.3
+//DEPS dev.snowdrop:buildpack-client:0.0.4-SNAPSHOT
 import java.io.File;
 import dev.snowdrop.buildpack.*;
 import dev.snowdrop.buildpack.docker.*;


### PR DESCRIPTION
This pull request does the following:

- Removes dependencies that are not really needed:
  - slf4j-simple: A library like this should not drag in the classpath a logging impl.
  - fingbugs annotations: It's not really used

- Define as optional dependencies that are compile time only (e.g. annotation processor).
- Tune release script so that samples use release version, but main branch switch back to SNAPSHOT right after release.
