### PR TITLE
chore: add maven central badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Java buildpack Client
 
 ![Build](https://github.com/snowdrop/java-buildpack-client/actions/workflows/build.yml/badge.svg)
-
+[![Maven Central](https://img.shields.io/maven-central/v/dev.snowdrop/buildpack-client.svg?label=Maven%20Central)](https://search.maven.org/search?q=g:%22dev.snowdrop%22%20AND%20a:%22buildpack-client%22)
 
 Prototype of a simple buildpack (https://buildpacks.io/) client for java.
 


### PR DESCRIPTION
The pull request adds a badge in the readme that shows the latest release that is available on central.