### PR TITLE
Restructuring for lifecycle phases

### DIFF
--- a/client/src/main/java/dev/snowdrop/buildpack/docker/Content.java
+++ b/client/src/main/java/dev/snowdrop/buildpack/docker/Content.java
@@ -4,6 +4,5 @@ package dev.snowdrop.buildpack.docker;
 import java.util.List;
 
 public interface Content {
-  
   List<ContainerEntry> getContainerEntries();
 }

--- a/client/src/main/java/dev/snowdrop/buildpack/docker/VolumeUtils.java
+++ b/client/src/main/java/dev/snowdrop/buildpack/docker/VolumeUtils.java
@@ -8,6 +8,8 @@ import com.github.dockerjava.api.exception.NotFoundException;
 
 public class VolumeUtils {
 
+  final static String mountPrefix = "/volumecontent";
+
   public static boolean createVolumeIfRequired(DockerClient dc, String volumeName) {
     if (!exists(dc, volumeName)) {
       return internalCreateVolume(dc, volumeName);
@@ -30,11 +32,16 @@ public class VolumeUtils {
   }
 
   public static boolean addContentToVolume(DockerClient dc, String volumeName, String pathInVolume, File content) {
-    return internalAddContentToVolume(dc, volumeName, new FileContent("/volumecontent", content).getContainerEntries());
+    return internalAddContentToVolume(dc, volumeName, mountPrefix, 0,0, new FileContent(content).getContainerEntries());
   }
 
   public static boolean addContentToVolume(DockerClient dc, String volumeName, String name, String content) {
-    return internalAddContentToVolume(dc, volumeName, new StringContent("/volumecontent/" + name, content).getContainerEntries());
+    return internalAddContentToVolume(dc, volumeName, mountPrefix, 0,0, new StringContent(name, content).getContainerEntries());
+  }
+
+  public static boolean addContentToVolume(DockerClient dc, String volumeName, String prefix, int uid, int gid, List<ContainerEntry> entries) {
+    if(!prefix.startsWith("/")) prefix = "/"+prefix;
+    return internalAddContentToVolume(dc, volumeName, mountPrefix+prefix, uid, gid, entries);
   }
 
   private static boolean internalCreateVolume(DockerClient dc, String volumeName) {
@@ -42,15 +49,15 @@ public class VolumeUtils {
     return exists(dc, volumeName);
   }
 
-  private static boolean internalAddContentToVolume(DockerClient dc, String volumeName, List<ContainerEntry> entries) {
-    return internalAddContentToVolume(dc, volumeName, entries.toArray(new ContainerEntry[entries.size()]));
+  private static boolean internalAddContentToVolume(DockerClient dc, String volumeName, String prefix, int uid, int gid, List<ContainerEntry> entries) {
+    return internalAddContentToVolume(dc, volumeName, prefix, uid, gid, entries.toArray(new ContainerEntry[entries.size()]));
   }
 
-  private static boolean internalAddContentToVolume(DockerClient dc, String volumeName, ContainerEntry... entries) {
+  private static boolean internalAddContentToVolume(DockerClient dc, String volumeName, String prefix, int uid, int gid, ContainerEntry... entries) {
     // TODO: find better 'no-op' container to use?
     String dummyId = ContainerUtils.createContainer(dc, "tianon/true", new VolumeBind(volumeName, "/volumecontent"));
 
-    ContainerUtils.addContentToContainer(dc, dummyId, entries);
+    ContainerUtils.addContentToContainer(dc, dummyId, prefix, uid, gid, entries);
 
     ContainerUtils.removeContainer(dc, dummyId);
 

--- a/client/src/main/java/dev/snowdrop/buildpack/phases/ContainerStatus.java
+++ b/client/src/main/java/dev/snowdrop/buildpack/phases/ContainerStatus.java
@@ -1,0 +1,11 @@
+package dev.snowdrop.buildpack.phases;
+
+import lombok.Data;
+import lombok.ToString;
+
+@ToString(includeFieldNames=true)
+@Data(staticConstructor="of")
+public class ContainerStatus {
+  final int rc;
+  final String containerId;
+}

--- a/client/src/main/java/dev/snowdrop/buildpack/phases/Creator.java
+++ b/client/src/main/java/dev/snowdrop/buildpack/phases/Creator.java
@@ -1,0 +1,64 @@
+package dev.snowdrop.buildpack.phases;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.github.dockerjava.api.command.WaitContainerResultCallback;
+import dev.snowdrop.buildpack.ContainerLogReader;
+
+
+public class Creator implements LifecyclePhase{
+
+    private static final Logger log = LoggerFactory.getLogger(Creator.class);
+
+    final LifecyclePhaseFactory factory;
+
+    public Creator( LifecyclePhaseFactory factory ){
+        this.factory = factory;
+    }
+
+    @Override
+    public ContainerStatus runPhase(dev.snowdrop.buildpack.Logger logger, boolean useTimestamps) {
+
+        // configure our call to 'creator' which will do all the work.
+        String[] args = { "/cnb/lifecycle/creator", 
+                        "-uid", "" + factory.buildUserId, 
+                        "-gid", "" + factory.buildGroupId, 
+                        "-cache-dir", LifecyclePhaseFactory.BUILD_VOL_PATH,
+                        "-app", LifecyclePhaseFactory.APP_VOL_PATH + "/content", 
+                        "-layers", LifecyclePhaseFactory.OUTPUT_VOL_PATH, 
+                        "-platform", LifecyclePhaseFactory.PLATFORM_VOL_PATH, 
+                        "-run-image", factory.runImageName, 
+                        "-launch-cache", LifecyclePhaseFactory.LAUNCH_VOL_PATH, 
+                        "-daemon", // TODO: non daemon support.
+                        "-log-level", factory.buildLogLevel, 
+                        "-skip-restore", factory.finalImageName };
+
+        // TODO: read metadata from builderImage to confirm lifecycle version/platform
+        // version compatibility.
+
+        // TODO: add labels for container for creator etc (as per spec)
+    
+        String id = factory.getContainerForPhase(args);
+        log.info("- build container id " + id);
+
+        // launch the container!
+        log.info("- launching build container");
+        factory.dockerClient.startContainerCmd(id).exec();
+
+        log.info("- attaching log relay");
+        // grab the logs to stdout.
+        factory.dockerClient.logContainerCmd(id)
+        .withFollowStream(true)
+        .withStdOut(true)
+        .withStdErr(true)
+        .withTimestamps(useTimestamps)
+        .exec(new ContainerLogReader(logger));
+
+        // wait for the container to complete, and retrieve the exit code.
+        int rc = factory.dockerClient.waitContainerCmd(id).exec(new WaitContainerResultCallback()).awaitStatusCode();
+        log.info("Buildpack container complete, with exit code " + rc);    
+
+        return ContainerStatus.of(rc,id);
+    }
+    
+}

--- a/client/src/main/java/dev/snowdrop/buildpack/phases/LifecyclePhase.java
+++ b/client/src/main/java/dev/snowdrop/buildpack/phases/LifecyclePhase.java
@@ -1,0 +1,7 @@
+package dev.snowdrop.buildpack.phases;
+
+import dev.snowdrop.buildpack.Logger;
+
+public interface LifecyclePhase {
+    public ContainerStatus runPhase(Logger logger, boolean useTimestamps);
+}

--- a/client/src/main/java/dev/snowdrop/buildpack/phases/LifecyclePhaseFactory.java
+++ b/client/src/main/java/dev/snowdrop/buildpack/phases/LifecyclePhaseFactory.java
@@ -1,0 +1,78 @@
+package dev.snowdrop.buildpack.phases;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import com.github.dockerjava.api.DockerClient;
+
+import dev.snowdrop.buildpack.docker.ContainerUtils;
+import dev.snowdrop.buildpack.docker.VolumeBind;
+
+
+
+public class LifecyclePhaseFactory {
+
+    //paths we use for mountpoints within build container.
+    public final static String BUILD_VOL_PATH = "/bld";
+    public final static String LAUNCH_VOL_PATH = "/launch";
+    public final static String APP_VOL_PATH = "/app";
+    public final static String OUTPUT_VOL_PATH = "/out";
+    public final static String PLATFORM_VOL_PATH = "/platform";
+    public final static String DOCKER_SOCKET_PATH = "/var/run/docker.sock";
+
+    //provided for this build by caller.
+    final DockerClient dockerClient;
+    final String dockerSocket;
+
+    final Integer buildUserId;
+    final Integer buildGroupId;
+    final String buildLogLevel;
+
+    //image names.
+    final String builderImageName;    
+    final String runImageName;
+    final String finalImageName;
+
+    //volume mappings.
+    final Map<String,String> volumePathsToVolumeNames;
+
+    public LifecyclePhaseFactory( DockerClient dockerClient,
+                                  String dockerSocket,
+                                  String builderImageName,
+                                  Integer buildUserId,
+                                  Integer buildGroupId,
+                                  String buildLogLevel,
+                                  String runImageName,
+                                  String finalImageName,
+                                  Map<String,String> volumePathsToVolumeNames
+                                ){
+        this.dockerClient = dockerClient;
+        this.dockerSocket = dockerSocket;
+
+        this.buildUserId = buildUserId;
+        this.buildGroupId = buildGroupId;
+        this.buildLogLevel = buildLogLevel;
+
+        this.builderImageName = builderImageName;        
+        this.runImageName = runImageName;
+        this.finalImageName = finalImageName;
+
+        this.volumePathsToVolumeNames = volumePathsToVolumeNames;
+    }
+
+    String getContainerForPhase(String args[]){
+        // create a container using builderImage that will invoke the creator process
+        String id = ContainerUtils.createContainer(this.dockerClient, this.builderImageName, Arrays.asList(args),
+        new VolumeBind(this.volumePathsToVolumeNames.get(LifecyclePhaseFactory.BUILD_VOL_PATH), LifecyclePhaseFactory.BUILD_VOL_PATH), 
+        new VolumeBind(this.volumePathsToVolumeNames.get(LifecyclePhaseFactory.LAUNCH_VOL_PATH), LifecyclePhaseFactory.LAUNCH_VOL_PATH),
+        new VolumeBind(this.volumePathsToVolumeNames.get(LifecyclePhaseFactory.APP_VOL_PATH), LifecyclePhaseFactory.APP_VOL_PATH), 
+        new VolumeBind(this.volumePathsToVolumeNames.get(LifecyclePhaseFactory.DOCKER_SOCKET_PATH), LifecyclePhaseFactory.DOCKER_SOCKET_PATH),
+        new VolumeBind(this.volumePathsToVolumeNames.get(LifecyclePhaseFactory.OUTPUT_VOL_PATH), LifecyclePhaseFactory.OUTPUT_VOL_PATH));
+        return id;
+    }
+
+    public LifecyclePhase getCreator(){
+        return new Creator(this);
+    }
+}
+ 


### PR DESCRIPTION
A fair bit of rework, moving phase logic out of buildpack into its new home, with a factory to hold onto common config for phases. Init sequences have also been adjusted to pull out elements that happen once (eg copying app to volume) vs each phase (creation of phase container, executing etc). 