### PR TITLE
Registry mode

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -61,5 +61,11 @@
             <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${version.slf4j}</version>
+            <scope>test</scope>    
+        </dependency>                
     </dependencies>
 </project>

--- a/client/src/main/java/dev/snowdrop/buildpack/Buildpack.java
+++ b/client/src/main/java/dev/snowdrop/buildpack/Buildpack.java
@@ -43,8 +43,10 @@ public class Buildpack {
   private final Integer pullTimeoutSeconds;
 
   private final String dockerHost;
+  private final String dockerSocket;
+  private final String dockerNetwork;
+  private final Boolean useDaemon;
 
-  private final boolean useDaemon;
   private final String buildCacheVolumeName;
   private final boolean removeBuildCacheAfterBuild;
   private final String launchCacheVolumeName;
@@ -63,18 +65,34 @@ public class Buildpack {
 
   private final int exitCode;
 
-  private final String dockerSocket;
 
-  public Buildpack(String builderImage, String runImage, String finalImage, Integer pullTimeoutSeconds, String dockerHost, String dockerSocket,
-      boolean useDaemon, String buildCacheVolumeName, boolean removeBuildCacheAfterBuild,
-      String launchCacheVolumeName, boolean removeLaunchCacheAfterBuild, String logLevel, boolean useTimestamps, Map<String, String> environment, List<Content> content, DockerClient dockerClient, dev.snowdrop.buildpack.Logger logger) {
+
+  public Buildpack(String builderImage, 
+                   String runImage, 
+                   String finalImage, 
+                   Integer pullTimeoutSeconds, 
+                   String dockerHost, 
+                   String dockerSocket,
+                   String dockerNetwork,
+                   Boolean useDaemon, 
+                   String buildCacheVolumeName, 
+                   boolean removeBuildCacheAfterBuild,
+                   String launchCacheVolumeName, 
+                   boolean removeLaunchCacheAfterBuild, 
+                   String logLevel, 
+                   boolean useTimestamps, 
+                   Map<String, String> environment, 
+                   List<Content> content, 
+                   DockerClient dockerClient,
+                   dev.snowdrop.buildpack.Logger logger) {
 
     this.builderImage = builderImage != null ? builderImage : DEFAULT_BUILD_IMAGE;
     this.runImage = runImage;
     this.finalImage = finalImage;
     this.pullTimeoutSeconds = pullTimeoutSeconds != null ? pullTimeoutSeconds : DEFAULT_PULL_TIMEOUT;
     this.dockerHost = dockerHost != null ? dockerHost : DockerClientUtils.getDockerHost();
-    this.useDaemon = useDaemon;
+    this.dockerNetwork = dockerNetwork;
+    this.useDaemon = useDaemon != null ? useDaemon : Boolean.TRUE; //default daemon to true for back compat.
     this.buildCacheVolumeName = buildCacheVolumeName;
     this.removeBuildCacheAfterBuild = removeBuildCacheAfterBuild || buildCacheVolumeName!=null;
     this.launchCacheVolumeName = launchCacheVolumeName;
@@ -164,6 +182,10 @@ public class Buildpack {
     return dockerSocket;
   }
 
+  public String getDockerNetwork() {
+    return dockerNetwork;
+  }
+
   public String getRunImage() {
     return runImage;
   }
@@ -180,7 +202,7 @@ public class Buildpack {
     return dockerHost;
   }
 
-  public boolean getUseDaemon() {
+  public Boolean getUseDaemon() {
     return useDaemon;
   }
 

--- a/client/src/main/java/dev/snowdrop/buildpack/TestDriver.java
+++ b/client/src/main/java/dev/snowdrop/buildpack/TestDriver.java
@@ -1,16 +1,31 @@
 package dev.snowdrop.buildpack;
 
 import java.io.File;
+import java.util.HashMap;
 
 public class TestDriver {
 
   public TestDriver() throws Exception {
+
+    //run this with 
+    // mvnw exec:java -Dexec.classpathScope="test"  -Dexec.mainClass="dev.snowdrop.buildpack.TestDriver"
+
+    System.setProperty("org.slf4j.simpleLogger.log.dev.snowdrop.buildpack","debug");
+    System.setProperty("org.slf4j.simpleLogger.log.dev.snowdrop.buildpack.docker","debug");
+    System.setProperty("org.slf4j.simpleLogger.log.dev.snowdrop.buildpack.phases","debug");
+
+    HashMap<String,String> env = new HashMap<>();
+    //env.put("CNB_USER_ID","0");
+
     Buildpack.builder()
-      .addNewFileContent()
-        .withFile(new File("/home/ozzy/Work/java-buildpack-client"))
-      .endFileContent()
-      .withFinalImage("test/testimage:latest")
+      .addNewFileContent(new File("/home/sample-springboot-java-app/"))
+      .withBuilderImage("localhost:5000/paketobuildpacks/builder:base")
+      .withFinalImage("testdriver/testimage:latest")
+      .withUseDaemon(true)
+      .withDockerNetwork("host")
+      .withLogger(new SystemLogger())
       .withLogLevel("debug")
+      .withEnvironment(env)
       .build();
   }
 

--- a/client/src/main/java/dev/snowdrop/buildpack/docker/ContainerUtils.java
+++ b/client/src/main/java/dev/snowdrop/buildpack/docker/ContainerUtils.java
@@ -41,11 +41,11 @@ public class ContainerUtils {
 
   public static String createContainer(DockerClient dc, String imageReference, List<String> command,
       VolumeBind... volumes) {
-        return createContainer(dc, imageReference, command, 0, null, null, volumes);
+        return createContainer(dc, imageReference, command, 0, null, null, null, volumes);
   }
 
   public static String createContainer(DockerClient dc, String imageReference, List<String> command,
-        Integer runAsId, Map<String,String> env, String securityOpts,
+        Integer runAsId, Map<String,String> env, String securityOpts, String network,
         VolumeBind... volumes) {
           
 
@@ -75,10 +75,9 @@ public class ContainerUtils {
       ccc.withCmd(command);
     }
 
-    // String networkMode="host";
-    // if (networkMode!=null){
-    //   ccc.getHostConfig().with
-    // }
+    if (network!=null){
+       ccc.withHostConfig(ccc.getHostConfig().withNetworkMode(network));
+    }
 
     CreateContainerResponse ccr = ccc.exec();
     return ccr.getId();

--- a/client/src/main/java/dev/snowdrop/buildpack/phases/LifecyclePhaseFactory.java
+++ b/client/src/main/java/dev/snowdrop/buildpack/phases/LifecyclePhaseFactory.java
@@ -1,16 +1,30 @@
 package dev.snowdrop.buildpack.phases;
 
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.github.dockerjava.api.DockerClient;
 
+import dev.snowdrop.buildpack.Buildpack;
+import dev.snowdrop.buildpack.docker.ContainerEntry;
 import dev.snowdrop.buildpack.docker.ContainerUtils;
+import dev.snowdrop.buildpack.docker.Content;
+import dev.snowdrop.buildpack.docker.StringContent;
 import dev.snowdrop.buildpack.docker.VolumeBind;
+import dev.snowdrop.buildpack.docker.VolumeUtils;
 
 
 
 public class LifecyclePhaseFactory {
+
+    private static final Logger log = LoggerFactory.getLogger(LifecyclePhaseFactory.class);
 
     //paths we use for mountpoints within build container.
     public final static String BUILD_VOL_PATH = "/bld";
@@ -19,6 +33,8 @@ public class LifecyclePhaseFactory {
     public final static String OUTPUT_VOL_PATH = "/out";
     public final static String PLATFORM_VOL_PATH = "/platform";
     public final static String DOCKER_SOCKET_PATH = "/var/run/docker.sock";
+
+    public final static String APP_PATH_PREFIX = "/content";
 
     //provided for this build by caller.
     final DockerClient dockerClient;
@@ -33,41 +49,123 @@ public class LifecyclePhaseFactory {
     final String runImageName;
     final String finalImageName;
 
-    //volume mappings.
-    final Map<String,String> volumePathsToVolumeNames;
+    //names of the volumes during runtime.
+    final String buildCacheVolume;
+    final String launchCacheVolume;
+    final String applicationVolume;
+    final String outputVolume;
+    final String platformVolume;
+    
+    final List<Content> content;
+    final Map<String,String> environment;
 
+    final boolean removeBuildCacheAfterBuild;
+    final boolean removeLaunchCacheAfterBuild;
+    
     public LifecyclePhaseFactory( DockerClient dockerClient,
-                                  String dockerSocket,
-                                  String builderImageName,
                                   Integer buildUserId,
                                   Integer buildGroupId,
-                                  String buildLogLevel,
-                                  String runImageName,
-                                  String finalImageName,
-                                  Map<String,String> volumePathsToVolumeNames
+                                  Buildpack buildConfig
                                 ){
         this.dockerClient = dockerClient;
-        this.dockerSocket = dockerSocket;
+        this.dockerSocket = buildConfig.getDockerSocket();    
 
         this.buildUserId = buildUserId;
         this.buildGroupId = buildGroupId;
-        this.buildLogLevel = buildLogLevel;
+        this.buildLogLevel = buildConfig.getLogLevel();
 
-        this.builderImageName = builderImageName;        
-        this.runImageName = runImageName;
-        this.finalImageName = finalImageName;
+        this.builderImageName = buildConfig.getBuilderImage();        
+        this.runImageName = buildConfig.getRunImage();
+        this.finalImageName = buildConfig.getFinalImage();
 
-        this.volumePathsToVolumeNames = volumePathsToVolumeNames;
+        this.content = buildConfig.getContent();
+        this.environment = buildConfig.getEnvironment()==null ? new HashMap<>() : buildConfig.getEnvironment();
+
+        this.removeBuildCacheAfterBuild = buildConfig.getRemoveBuildCacheAfterBuild();
+        this.removeLaunchCacheAfterBuild = buildConfig.getRemoveLaunchCacheAfterBuild();
+
+        this.buildCacheVolume = buildConfig.getBuildCacheVolumeName() == null ? "buildpack-build-" + randomString(10) : buildConfig.getBuildCacheVolumeName();
+        this.launchCacheVolume = buildConfig.getLaunchCacheVolumeName() == null ? "buildpack-launch-" + randomString(10) : buildConfig.getLaunchCacheVolumeName();
+        this.applicationVolume = "buildpack-app-" + randomString(10);
+        this.outputVolume = "buildpack-output-" + randomString(10);
+        this.platformVolume = "buildpack-platform-" + randomString(10);
+
+        prep();
     }
 
-    String getContainerForPhase(String args[]){
+    private void prep(){
+        // create the volumes.
+        VolumeUtils.createVolumeIfRequired(dockerClient, buildCacheVolume);
+        VolumeUtils.createVolumeIfRequired(dockerClient, launchCacheVolume);
+        VolumeUtils.createVolumeIfRequired(dockerClient, applicationVolume);
+        VolumeUtils.createVolumeIfRequired(dockerClient, outputVolume);
+        VolumeUtils.createVolumeIfRequired(dockerClient, platformVolume);
+
+        // add the application to the volume. Note we are placing it at /content,
+        // because the volume mountpoint is mounted such that the user has no perms to create 
+        // new content there, but subdirs are ok.
+        List<ContainerEntry> appEntries = content
+            .stream()
+            .flatMap(c -> c.getContainerEntries().stream())
+            .collect(Collectors.toList());
+        VolumeUtils.addContentToVolume(dockerClient, applicationVolume, LifecyclePhaseFactory.APP_PATH_PREFIX, buildUserId, buildGroupId, appEntries);
+
+        //add the environment entries to the platform volume.
+        List<ContainerEntry> envEntries = environment.entrySet()
+            .stream()
+            .flatMap(e -> new StringContent(e.getKey(), e.getValue()).getContainerEntries().stream())
+            .collect(Collectors.toList());
+        VolumeUtils.addContentToVolume(dockerClient, platformVolume, "/env", buildUserId, buildGroupId, envEntries);  
+        
+        //add workarounds to environment.
+        if(!environment.containsKey("CNB_PLATFORM_API")) environment.put("CNB_PLATFORM_API", "0.4");
+        // This a workaround for a bug in older lifecyle revisions. https://github.com/buildpacks/lifecycle/issues/339        
+        if(!environment.containsKey("CNB_REGISTRY_AUTH")) environment.put("CNB_REGISTRY_AUTH", "{}");
+    }
+
+    // util method for random suffix.
+    private String randomString(int length) {
+        return (new Random()).ints('a', 'z' + 1).limit(length)
+            .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append).toString();
+    }    
+
+    public void tidyUp(){
+        // remove volumes
+        // (note when/if we persist the cache between builds, we'll be more selective here over what we remove)
+        if (removeBuildCacheAfterBuild) {
+            VolumeUtils.removeVolume(dockerClient, buildCacheVolume);
+        }
+        if (removeLaunchCacheAfterBuild) {
+            VolumeUtils.removeVolume(dockerClient, launchCacheVolume);
+        }
+        VolumeUtils.removeVolume(dockerClient, applicationVolume);
+        VolumeUtils.removeVolume(dockerClient, outputVolume);
+        VolumeUtils.removeVolume(dockerClient, platformVolume);
+    
+        log.info("- build volumes tidied up");     
+    }
+
+
+    String getContainerForPhase(String args[], Integer runAsId){
         // create a container using builderImage that will invoke the creator process
-        String id = ContainerUtils.createContainer(this.dockerClient, this.builderImageName, Arrays.asList(args),
-        new VolumeBind(this.volumePathsToVolumeNames.get(LifecyclePhaseFactory.BUILD_VOL_PATH), LifecyclePhaseFactory.BUILD_VOL_PATH), 
-        new VolumeBind(this.volumePathsToVolumeNames.get(LifecyclePhaseFactory.LAUNCH_VOL_PATH), LifecyclePhaseFactory.LAUNCH_VOL_PATH),
-        new VolumeBind(this.volumePathsToVolumeNames.get(LifecyclePhaseFactory.APP_VOL_PATH), LifecyclePhaseFactory.APP_VOL_PATH), 
-        new VolumeBind(this.volumePathsToVolumeNames.get(LifecyclePhaseFactory.DOCKER_SOCKET_PATH), LifecyclePhaseFactory.DOCKER_SOCKET_PATH),
-        new VolumeBind(this.volumePathsToVolumeNames.get(LifecyclePhaseFactory.OUTPUT_VOL_PATH), LifecyclePhaseFactory.OUTPUT_VOL_PATH));
+        String id = ContainerUtils.createContainer(this.dockerClient, this.builderImageName, Arrays.asList(args), 
+        runAsId, environment, "label=disable",
+        new VolumeBind(buildCacheVolume, LifecyclePhaseFactory.BUILD_VOL_PATH), 
+        new VolumeBind(launchCacheVolume, LifecyclePhaseFactory.LAUNCH_VOL_PATH),
+        new VolumeBind(applicationVolume, LifecyclePhaseFactory.APP_VOL_PATH), 
+        new VolumeBind(platformVolume, LifecyclePhaseFactory.PLATFORM_VOL_PATH),
+        new VolumeBind(dockerSocket, LifecyclePhaseFactory.DOCKER_SOCKET_PATH),
+        new VolumeBind(outputVolume, LifecyclePhaseFactory.OUTPUT_VOL_PATH)
+        );
+
+        log.info("- mounted " + buildCacheVolume + " at " + BUILD_VOL_PATH);
+        log.info("- mounted " + launchCacheVolume + " at " + LAUNCH_VOL_PATH);
+        log.info("- mounted " + applicationVolume + " at " + APP_VOL_PATH);
+        log.info("- mounted " + platformVolume + " at " + PLATFORM_VOL_PATH);
+        log.info("- mounted " + dockerSocket + " at " + LifecyclePhaseFactory.DOCKER_SOCKET_PATH);
+        log.info("- mounted " + outputVolume + " at " + OUTPUT_VOL_PATH);
+        log.info("- build container id " + id);        
+
         return id;
     }
 

--- a/client/src/main/java/dev/snowdrop/buildpack/utils/BuildpackMetadata.java
+++ b/client/src/main/java/dev/snowdrop/buildpack/utils/BuildpackMetadata.java
@@ -6,11 +6,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class BuildpackMetadata {
-    public static String getRunImageFromMetadata(String json, String runImage) throws BuildpackException {
-
-        // if caller set runImage, that choice overrides metadata.
-        if(runImage!=null)
-            return runImage;
+    public static String getRunImageFromMetadata(String json) throws BuildpackException {
 
         // else, dig into metadata for runImage.
         ObjectMapper om = new ObjectMapper();

--- a/client/src/test/java/dev/snowdrop/buildpack/docker/ContainerUtilsTest.java
+++ b/client/src/test/java/dev/snowdrop/buildpack/docker/ContainerUtilsTest.java
@@ -60,7 +60,7 @@ class ContainerUtilsTest {
     String result = ContainerUtils.createContainer(dc, "testImageRef");
     assertEquals(result, containerId);
 
-    verify(ccc, atLeastOnce()).withUser("root");
+    verify(ccc, atLeastOnce()).withUser("0");
     verify(ccc, atLeastOnce()).getHostConfig();
     verify(hc, atLeastOnce()).withBinds(eq(Collections.<Bind>emptyList()));
     verify(ccc).exec();
@@ -84,7 +84,7 @@ class ContainerUtilsTest {
     String result = ContainerUtils.createContainer(dc, "testImageRef", commands);
     assertEquals(result, containerId);
 
-    verify(ccc, atLeastOnce()).withUser("root");
+    verify(ccc, atLeastOnce()).withUser("0");
     verify(ccc, atLeastOnce()).getHostConfig();
     verify(hc, atLeastOnce()).withBinds(eq(Collections.<Bind>emptyList()));
     verify(ccc).exec();
@@ -111,7 +111,7 @@ class ContainerUtilsTest {
     String result = ContainerUtils.createContainer(dc, "testImageRef", commands, one, two);
     assertEquals(result, containerId);
 
-    verify(ccc, atLeastOnce()).withUser("root");
+    verify(ccc, atLeastOnce()).withUser("0");
     verify(ccc, atLeastOnce()).getHostConfig();
 
     // allow binds in either other.

--- a/client/src/test/java/dev/snowdrop/buildpack/docker/VolumeUtilsTest.java
+++ b/client/src/test/java/dev/snowdrop/buildpack/docker/VolumeUtilsTest.java
@@ -188,12 +188,8 @@ class VolumeUtilsTest {
                 //TODO: not sure why, but mockito invokes the verify twice, but the underlying stream is already depleted on the 2nd. 
                 //      since it doesn't apply to the real code, just gate on when the stream has data to only check it the first time.
                 if(is.available()>0){
-                    System.out.println("is "+is);
                     assertNotNull(is);
-
                     String r = new BufferedReader(new InputStreamReader(is)).readLine();
-
-                    System.out.println("content: "+r);
                     assertEquals(fileContent, r);
                 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <java.source>1.8</java.source>
     <java.target>1.8</java.target>
     <!-- Dependency Versions -->
-    <version.docker-java>3.2.7</version.docker-java>
+    <version.docker-java>3.2.13</version.docker-java>
     <version.slf4j>1.7.30</version.slf4j>
     <version.commons-compress>1.20</version.commons-compress>
     <version.jackson>2.12.3</version.jackson>


### PR DESCRIPTION
Adds ability to build images without the docker daemon flag. This means the docker socket is not mounted into the build container, and the resulting image must be pulled back from the registry if required to be used locally. 

To use registry mode, just set withUseDaemon(false) and withFinalImageName("registry:port/thing/name:tag") 

(note if, like me, you are using a local docker registry at 'localhost:5000' then you need to also use withDockerNetwork("host") because otherwise 'localhost' inside the the container running the build, will mean something different than the 'localhost' where you are running the registry)

Docker authentication will be addressed separately. Most likely by exposing the DockerClient object from the underlying docker api. 

resolves 6

