### PR TITLE
Pass correct logger to the build process

### DIFF
--- a/client/src/main/java/dev/snowdrop/buildpack/Buildpack.java
+++ b/client/src/main/java/dev/snowdrop/buildpack/Buildpack.java
@@ -110,10 +110,10 @@ public class Buildpack {
 
 
     //run the build.
-    this.exitCode = build(logger);
+    this.exitCode = build();
   }
 
-  private int build(dev.snowdrop.buildpack.Logger logger) {
+  private int build() {
 
     log.info("Buildpack build invoked, preparing environment...");
     prep();


### PR DESCRIPTION
It looks like the variable, not field is used, leading to NPE in `ContainerLogReader`.