### PR TITLE
Update release script sed

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -19,7 +19,7 @@ fi
 # Set release version in the samples & readme
 #
 find ./samples/ -iwholename "*/pack.java" | while read f; do
-    sed -i "s/\/\/DEPS dev.snowdrop:buildpack-client:.*/\/\/DEPS dev.snowdrop:buildpack-client:${release_version}/g" $f
+    sed -i "s/dev.snowdrop:buildpack-client:.*/dev.snowdrop:buildpack-client:${release_version}\}/g" $f
     git add $f
 done
 sed -i "s/\/\/DEPS dev.snowdrop:buildpack-client:.*/\/\/DEPS dev.snowdrop:buildpack-client:${release_version}/g" README.md


### PR DESCRIPTION
Quick fix to update the release script to be less discriminating when updating the buildpack-client dep version
works because `buildpack-client` is not used as a package name, so it won't clash.. the add back of the final } is a bit hacky, but it gets the job done.