### PR TITLE
Add docker config to tailor image pull behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ The [`BuildpackConfig`](client/src/main/java/dev/snowdrop/buildpack/BuildConfig.
 
 - run/build/output Image can be specified
 - docker can be configured with.. 
-    - pull timeout
+    - pull timeout 
+    - pull retry count (will retry image pull on failure)
+    - pull retry timeout increase (increases timeout each time pull is retried)
     - host
     - network
     - docker socket path

--- a/client/src/main/java/dev/snowdrop/buildpack/BuilderImage.java
+++ b/client/src/main/java/dev/snowdrop/buildpack/BuilderImage.java
@@ -44,9 +44,7 @@ public class BuilderImage {
         image = builderImage;
 
         // pull and inspect the builderImage to obtain builder metadata.
-        ImageUtils.pullImages(dc.getDockerClient(), 
-                              dc.getPullTimeout(), 
-                              builderImage.getReference());
+        ImageUtils.pullImages(dc, builderImage.getReference());
 
         ImageInfo ii = ImageUtils.inspectImage(dc.getDockerClient(), 
                                                builderImage.getReference());

--- a/client/src/main/java/dev/snowdrop/buildpack/config/DockerConfig.java
+++ b/client/src/main/java/dev/snowdrop/buildpack/config/DockerConfig.java
@@ -12,9 +12,17 @@ public class DockerConfig {
         return new DockerConfigBuilder();
     }
 
+    public static enum PullPolicy {ALWAYS, IF_NOT_PRESENT};
+
     private static final Integer DEFAULT_PULL_TIMEOUT = 60;
+    private static final Integer DEFAULT_PULL_RETRY_INCREASE = 15;
+    private static final Integer DEFAULT_PULL_RETRY_COUNT = 3;
+    private static final PullPolicy DEFAULT_PULL_POLICY = PullPolicy.IF_NOT_PRESENT;
     
     private Integer pullTimeoutSeconds;
+    private Integer pullRetryCount;
+    private Integer pullRetryIncreaseSeconds;
+    private PullPolicy pullPolicy;
     private String dockerHost;
     private String dockerSocket;
     private String dockerNetwork;
@@ -23,13 +31,19 @@ public class DockerConfig {
 
     public DockerConfig(                   
         Integer pullTimeoutSeconds, 
+        Integer pullRetryCount,
+        Integer pullRetryIncreaseSeconds,
+        PullPolicy pullPolicy,
         String dockerHost, 
         String dockerSocket,
         String dockerNetwork,
         Boolean useDaemon, 
         DockerClient dockerClient
     ){
-        this.pullTimeoutSeconds = pullTimeoutSeconds != null ? pullTimeoutSeconds : DEFAULT_PULL_TIMEOUT;
+        this.pullTimeoutSeconds = pullTimeoutSeconds != null ? Integer.max(0,pullTimeoutSeconds) : DEFAULT_PULL_TIMEOUT;
+        this.pullRetryCount = pullRetryCount != null ? Integer.max(0,pullRetryCount) : DEFAULT_PULL_RETRY_COUNT;
+        this.pullRetryIncreaseSeconds = pullRetryIncreaseSeconds != null ? Integer.max(0,pullRetryIncreaseSeconds) : DEFAULT_PULL_RETRY_INCREASE;
+        this.pullPolicy = pullPolicy != null ? pullPolicy : DEFAULT_PULL_POLICY;
         this.dockerHost = dockerHost != null ? dockerHost : DockerClientUtils.getDockerHost();
         this.dockerSocket = dockerSocket != null ? dockerSocket : (this.dockerHost.startsWith("unix://") ? this.dockerHost.substring("unix://".length()) : "/var/run/docker.sock");
         this.dockerNetwork = dockerNetwork;
@@ -45,6 +59,18 @@ public class DockerConfig {
 
     public Integer getPullTimeout(){
         return this.pullTimeoutSeconds;
+    }
+
+    public Integer getPullRetryCount(){
+        return this.pullRetryCount;
+    }
+
+    public Integer getPullRetryIncrease(){
+        return this.pullRetryIncreaseSeconds;
+    }
+
+    public PullPolicy getPullPolicy(){
+        return this.pullPolicy;
     }
 
     public String getDockerHost(){

--- a/client/src/main/java/dev/snowdrop/buildpack/lifecycle/LifecycleExecutor.java
+++ b/client/src/main/java/dev/snowdrop/buildpack/lifecycle/LifecycleExecutor.java
@@ -105,7 +105,7 @@ public class LifecycleExecutor {
                         }
 
                         //pull the new image.. 
-                        ImageUtils.pullImages(config.getDockerConfig().getDockerClient(), factory.getDockerConfig().getPullTimeout(), newRunImage);
+                        ImageUtils.pullImages(config.getDockerConfig(), newRunImage);
 
                         //update run image associated with our builder image.
                         factory.getBuilderImage().getRunImages(activePlatformLevel).clear();

--- a/client/src/main/java/dev/snowdrop/buildpack/utils/LifecycleMetadata.java
+++ b/client/src/main/java/dev/snowdrop/buildpack/utils/LifecycleMetadata.java
@@ -20,9 +20,7 @@ public class LifecycleMetadata {
     public LifecycleMetadata(DockerConfig dc, ImageReference lifecycleImage) throws BuildpackException {
 
         // pull and inspect the builderImage to obtain builder metadata.
-        ImageUtils.pullImages(dc.getDockerClient(), 
-                              dc.getPullTimeout(), 
-                              lifecycleImage.getReference());
+        ImageUtils.pullImages(dc,lifecycleImage.getReference());
 
         ImageInfo ii = ImageUtils.inspectImage(dc.getDockerClient(), 
                                                lifecycleImage.getReference());

--- a/client/src/test/java/dev/snowdrop/buildpack/config/DockerConfigTest.java
+++ b/client/src/test/java/dev/snowdrop/buildpack/config/DockerConfigTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,20 +19,21 @@ import com.github.dockerjava.api.command.PingCmd;
 public class DockerConfigTest {
     @Test
     void checkTimeout() {
-        DockerConfig dc1 = new DockerConfig(null, null, null, null, null, null);
+        DockerConfig dc1 = new DockerConfig(null, null, null, null, null, null, null, null, null);
         assertEquals(60, dc1.getPullTimeout());
 
-        DockerConfig dc2 = new DockerConfig(245017, null, null, null, null, null);
+        DockerConfig dc2 = new DockerConfig(245017, null, null, null, null, null, null, null, null);
         assertEquals(dc2.getPullTimeout(), 245017);
     }
 
     @Test
     void checkDockerHost(@Mock DockerClient dockerClient, @Mock PingCmd pingCmd) {
-        DockerConfig dc1 = new DockerConfig(null, null, null, null, null, null);
+        lenient().when(dockerClient.pingCmd()).thenReturn(pingCmd);
+
+        DockerConfig dc1 = new DockerConfig(null, null, null, null, null, null, null, null, null);
         assertNotNull(dc1.getDockerHost());
 
-        when(dockerClient.pingCmd()).thenReturn(pingCmd);
-        DockerConfig dc2 = new DockerConfig(null, "tcp://stilettos", null, null, null, dockerClient);
+        DockerConfig dc2 = new DockerConfig(null, null, null, null, "tcp://stilettos", null, null, null, dockerClient);
         assertEquals("tcp://stilettos", dc2.getDockerHost());
     }
 
@@ -42,37 +42,37 @@ public class DockerConfigTest {
 
         lenient().when(dockerClient.pingCmd()).thenReturn(pingCmd);
 
-        DockerConfig dc1 = new DockerConfig(null, null, null, null, null, null);
+        DockerConfig dc1 = new DockerConfig(null, null, null, null, null, null, null, null, null);
         assertNotNull(dc1.getDockerSocket());
 
-        DockerConfig dc2 = new DockerConfig(null, "unix:///stilettos", null, null, null, dockerClient);
+        DockerConfig dc2 = new DockerConfig(null, null, null, null, "unix:///stilettos", null, null, null, dockerClient);
         assertEquals("/stilettos", dc2.getDockerSocket());
 
-        DockerConfig dc3 = new DockerConfig(null, "tcp://stilettos", null, null, null, dockerClient);
+        DockerConfig dc3 = new DockerConfig(null, null, null, null, "tcp://stilettos", null, null, null, dockerClient);
         assertEquals("/var/run/docker.sock", dc3.getDockerSocket());
 
-        DockerConfig dc4 = new DockerConfig(null, null, "fish", null, null, null);
+        DockerConfig dc4 = new DockerConfig(null, null, null, null, null, "fish", null, null, null);
         assertEquals("fish", dc4.getDockerSocket());
     }
 
     @Test
     void checkDockerNetwork() {
-        DockerConfig dc1 = new DockerConfig(null, null, null, "kitten", null, null);
+        DockerConfig dc1 = new DockerConfig(null, null, null, null, null, null, "kitten", null, null);
         assertEquals("kitten", dc1.getDockerNetwork());
 
-        DockerConfig dc2 = new DockerConfig(null, null, null, null, null, null);
+        DockerConfig dc2 = new DockerConfig(null, null, null, null, null, null, null, null, null);
         assertNull(dc2.getDockerNetwork());
     }
 
     @Test
     void checkUseDaemon() {
-        DockerConfig dc1 = new DockerConfig(null, null, null, null, null, null);
+        DockerConfig dc1 = new DockerConfig(null, null, null, null, null, null, null, null, null);
         assertTrue(dc1.getUseDaemon());
 
-        DockerConfig dc2 = new DockerConfig(null, null, null, null, true, null);
+        DockerConfig dc2 = new DockerConfig(null, null, null, null, null, null, null, true, null);
         assertTrue(dc2.getUseDaemon());
 
-        DockerConfig dc3 = new DockerConfig(null, null, null, null, false, null);
+        DockerConfig dc3 = new DockerConfig(null, null, null, null, null, null, null, false, null);
         assertFalse(dc3.getUseDaemon());
     }
 
@@ -80,10 +80,39 @@ public class DockerConfigTest {
     void checkDockerClient(@Mock DockerClient dockerClient, @Mock PingCmd pingCmd){
         lenient().when(dockerClient.pingCmd()).thenReturn(pingCmd);
 
-        DockerConfig dc1 = new DockerConfig(null, null, null, null, null, null);
+        DockerConfig dc1 = new DockerConfig(null, null, null, null, null, null, null, null, null);
         assertNotNull(dc1.getDockerClient());
 
-        DockerConfig dc2 = new DockerConfig(null, null, null, null, null, dockerClient);
+        DockerConfig dc2 = new DockerConfig(null, null, null, null, null, null, null, null, dockerClient);
         assertEquals(dockerClient, dc2.getDockerClient());
     }
+
+    @Test
+    void checkPullPolicy(@Mock DockerClient dockerClient, @Mock PingCmd pingCmd){
+        lenient().when(dockerClient.pingCmd()).thenReturn(pingCmd);
+
+        DockerConfig dc1 = new DockerConfig(null, null, null, null, null, null, null, null, dockerClient);
+        assertEquals(DockerConfig.PullPolicy.IF_NOT_PRESENT, dc1.getPullPolicy());
+
+        DockerConfig dc2 = new DockerConfig(null, null, null, DockerConfig.PullPolicy.IF_NOT_PRESENT, null, null, null, null, dockerClient);
+        assertEquals(DockerConfig.PullPolicy.IF_NOT_PRESENT, dc2.getPullPolicy());
+
+        DockerConfig dc3 = new DockerConfig(null, null, null, DockerConfig.PullPolicy.ALWAYS, null, null, null, null, dockerClient);
+        assertEquals(DockerConfig.PullPolicy.ALWAYS, dc3.getPullPolicy());        
+    }  
+    
+
+    @Test
+    void checkPullRetry(@Mock DockerClient dockerClient, @Mock PingCmd pingCmd){
+        lenient().when(dockerClient.pingCmd()).thenReturn(pingCmd);
+
+        DockerConfig dc1 = new DockerConfig(null, null, null, null, null, null, null, null, dockerClient);
+        assertEquals(3, dc1.getPullRetryCount());
+
+        DockerConfig dc2 = new DockerConfig(null, 5, null, null, null, null, null, null, dockerClient);
+        assertEquals(5, dc2.getPullRetryCount());
+
+        DockerConfig dc3 = new DockerConfig(null, 0, null, null, null, null, null, null, dockerClient);
+        assertEquals(0, dc3.getPullRetryCount());        
+    }     
 }

--- a/client/src/test/java/dev/snowdrop/buildpack/lifecycle/LifecycleExecutorTest.java
+++ b/client/src/test/java/dev/snowdrop/buildpack/lifecycle/LifecycleExecutorTest.java
@@ -87,6 +87,7 @@ public class LifecycleExecutorTest {
 
         lenient().when(dockerConfig.getDockerClient()).thenReturn(dockerClient);
         lenient().when(dockerConfig.getPullTimeout()).thenReturn(66);
+        lenient().when(dockerConfig.getPullPolicy()).thenReturn(DockerConfig.PullPolicy.IF_NOT_PRESENT);
 
         lenient().when(config.getDockerConfig()).thenReturn(dockerConfig);
         lenient().when(config.getBuildCacheConfig()).thenReturn(buildCacheConfig);
@@ -123,7 +124,7 @@ public class LifecycleExecutorTest {
             MockedStatic<? extends ImageUtils> imageUtils = mockStatic(ImageUtils.class)) {
 
             containerUtils.when(() -> ContainerUtils.removeContainer(eq(dockerClient), any())).thenAnswer(Answers.RETURNS_DEFAULTS);
-            imageUtils.when(() -> ImageUtils.pullImages(dockerClient, 66, "newfish")).thenAnswer(Answers.RETURNS_DEFAULTS);
+            imageUtils.when(() -> ImageUtils.pullImages(dockerConfig, "newfish")).thenAnswer(Answers.RETURNS_DEFAULTS);
 
             LifecycleExecutor le = new LifecycleExecutor(config, extendedBuilder, origBuilder, PLATFORM_LEVEL);
             
@@ -190,6 +191,7 @@ public class LifecycleExecutorTest {
 
         lenient().when(dockerConfig.getDockerClient()).thenReturn(dockerClient);
         lenient().when(dockerConfig.getPullTimeout()).thenReturn(66);
+        lenient().when(dockerConfig.getPullPolicy()).thenReturn(DockerConfig.PullPolicy.IF_NOT_PRESENT);
 
         lenient().when(config.getDockerConfig()).thenReturn(dockerConfig);
         lenient().when(config.getBuildCacheConfig()).thenReturn(buildCacheConfig);
@@ -226,7 +228,7 @@ public class LifecycleExecutorTest {
             MockedStatic<? extends ImageUtils> imageUtils = mockStatic(ImageUtils.class)) {
 
             containerUtils.when(() -> ContainerUtils.removeContainer(eq(dockerClient), any())).thenAnswer(Answers.RETURNS_DEFAULTS);
-            imageUtils.when(() -> ImageUtils.pullImages(dockerClient, 66, "newfish")).thenAnswer(Answers.RETURNS_DEFAULTS);
+            imageUtils.when(() -> ImageUtils.pullImages(dockerConfig,"newfish")).thenAnswer(Answers.RETURNS_DEFAULTS);
 
             LifecycleExecutor le = new LifecycleExecutor(config, extendedBuilder, origBuilder, PLATFORM_LEVEL);
             
@@ -291,6 +293,7 @@ public class LifecycleExecutorTest {
         lenient().when(logConfig.getUseTimestamps()).thenReturn(true);
         lenient().when(logConfig.getLogger()).thenReturn(logger);
 
+        lenient().when(dockerConfig.getPullPolicy()).thenReturn(DockerConfig.PullPolicy.IF_NOT_PRESENT);
         lenient().when(dockerConfig.getDockerClient()).thenReturn(dockerClient);
         lenient().when(dockerConfig.getPullTimeout()).thenReturn(66);
 
@@ -329,7 +332,7 @@ public class LifecycleExecutorTest {
             MockedStatic<? extends ImageUtils> imageUtils = mockStatic(ImageUtils.class)) {
 
             containerUtils.when(() -> ContainerUtils.removeContainer(eq(dockerClient), any())).thenAnswer(Answers.RETURNS_DEFAULTS);
-            imageUtils.when(() -> ImageUtils.pullImages(dockerClient, 66, "newfish")).thenAnswer(Answers.RETURNS_DEFAULTS);
+            imageUtils.when(() -> ImageUtils.pullImages(dockerConfig, "newfish")).thenAnswer(Answers.RETURNS_DEFAULTS);
 
             LifecycleExecutor le = new LifecycleExecutor(config, extendedBuilder, origBuilder, PLATFORM_LEVEL);
             
@@ -395,6 +398,7 @@ public class LifecycleExecutorTest {
         lenient().when(logConfig.getUseTimestamps()).thenReturn(true);
         lenient().when(logConfig.getLogger()).thenReturn(logger);
 
+        lenient().when(dockerConfig.getPullPolicy()).thenReturn(DockerConfig.PullPolicy.IF_NOT_PRESENT);
         lenient().when(dockerConfig.getDockerClient()).thenReturn(dockerClient);
         lenient().when(dockerConfig.getPullTimeout()).thenReturn(66);
 
@@ -437,7 +441,7 @@ public class LifecycleExecutorTest {
             MockedStatic<? extends ImageUtils> imageUtils = mockStatic(ImageUtils.class)) {
 
             containerUtils.when(() -> ContainerUtils.removeContainer(eq(dockerClient), any())).thenAnswer(Answers.RETURNS_DEFAULTS);
-            imageUtils.when(() -> ImageUtils.pullImages(dockerClient, 66, "newfish")).thenAnswer(Answers.RETURNS_DEFAULTS);
+            imageUtils.when(() -> ImageUtils.pullImages(dockerConfig, "newfish")).thenAnswer(Answers.RETURNS_DEFAULTS);
 
             LifecycleExecutor le = new LifecycleExecutor(config, extendedBuilder, origBuilder, PLATFORM_LEVEL);
             
@@ -506,6 +510,7 @@ public class LifecycleExecutorTest {
         lenient().when(logConfig.getUseTimestamps()).thenReturn(true);
         lenient().when(logConfig.getLogger()).thenReturn(logger);
 
+        lenient().when(dockerConfig.getPullPolicy()).thenReturn(DockerConfig.PullPolicy.IF_NOT_PRESENT);
         lenient().when(dockerConfig.getDockerClient()).thenReturn(dockerClient);
         lenient().when(dockerConfig.getPullTimeout()).thenReturn(66);
 
@@ -548,7 +553,7 @@ public class LifecycleExecutorTest {
             MockedStatic<? extends ImageUtils> imageUtils = mockStatic(ImageUtils.class)) {
 
             containerUtils.when(() -> ContainerUtils.removeContainer(eq(dockerClient), any())).thenAnswer(Answers.RETURNS_DEFAULTS);
-            imageUtils.when(() -> ImageUtils.pullImages(dockerClient, 66, "newfish")).thenAnswer(Answers.RETURNS_DEFAULTS);
+            imageUtils.when(() -> ImageUtils.pullImages(dockerConfig, "newfish")).thenAnswer(Answers.RETURNS_DEFAULTS);
 
             LifecycleExecutor le = new LifecycleExecutor(config, extendedBuilder, origBuilder, PLATFORM_LEVEL);
             

--- a/samples/hello-quarkus/pack.java
+++ b/samples/hello-quarkus/pack.java
@@ -20,8 +20,8 @@ public class pack {
       System.setProperty("org.slf4j.simpleLogger.log.dev.snowdrop.buildpack.lifecycle.phases","debug");      
 
       int exitCode = BuildConfig.builder()
-                           .withBuilderImage(new ImageReference("paketocommunity/builder-ubi-base:latest"))
-                           .withOutputImage(new ImageReference("snowdrop/hello-quarkus:latest"))
+                           .withBuilderImage(new ImageReference("docker.io/paketocommunity/builder-ubi-base"))
+                           .withOutputImage(new ImageReference("snowdrop/hello-quarkus"))
                            .withNewLogConfig()
                               .withLogger(new SystemLogger())
                               .withLogLevel("debug")

--- a/samples/hello-spring/pack.java
+++ b/samples/hello-spring/pack.java
@@ -22,8 +22,8 @@ public class pack {
         HashMap<String,String> env = new HashMap<>();
 
         int exitCode = BuildConfig.builder()
-                           .withBuilderImage(new ImageReference("paketocommunity/builder-ubi-base:latest"))             
-                           .withOutputImage(new ImageReference("snowdrop/hello-spring:latest"))
+                           .withBuilderImage(new ImageReference("docker.io/paketocommunity/builder-ubi-base"))             
+                           .withOutputImage(new ImageReference("snowdrop/hello-spring"))
                            .withNewLogConfig()
                                 .withLogger(new SystemLogger())
                                 .withLogLevel("debug")


### PR DESCRIPTION
Integration tests have frequently failed with docker pull failures.. this adds code to allow configuring a retry count, and adds image pull policies of always / if not present (we don't support a pull policy of never, because the build will fail either way!)

Creating PR to test if this helps the integration test actions =)