### PR TITLE
Clear entrypoint when setting command

### DIFF
--- a/client/src/main/java/dev/snowdrop/buildpack/docker/ContainerUtils.java
+++ b/client/src/main/java/dev/snowdrop/buildpack/docker/ContainerUtils.java
@@ -107,6 +107,7 @@ public class ContainerUtils {
 
     if (command != null) {
       ccc.withCmd(command);
+      ccc.withEntrypoint("");
     }
 
     if (network!=null){


### PR DESCRIPTION
If a builder image has an entrypoint (say via inheritance from it's base builder image) then in order for the snowdrop buildpack lib to function correctly, we must wipe the entrypoint when setting the command, else we'll invoke the wrong thing.