### PR TITLE
Update release to 0.11

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,3 +1,3 @@
 release:
-  current-version: 0.0.10
-  next-version: 0.0.11-SNAPSHOT
+  current-version: 0.0.11
+  next-version: 0.0.12-SNAPSHOT


### PR DESCRIPTION
This adds a fix to clear the entrypoint when setting docker commands, which resolves issues with builders extending docker images with entrypoint set