### PR TITLE
Add authconfigs to client, add logging

### DIFF
--- a/client/src/main/java/dev/snowdrop/buildpack/docker/DockerClientUtils.java
+++ b/client/src/main/java/dev/snowdrop/buildpack/docker/DockerClientUtils.java
@@ -55,6 +55,7 @@ public class DockerClientUtils {
         .build();
 
     AuthDelegatingDockerClientConfig addcc = new AuthDelegatingDockerClientConfig(config);
+    addcc.setRegistryAuthConfigs(authConfigs);
 
     DockerHttpClient httpClient = new ApacheDockerHttpClient.Builder()
         .dockerHost(config.getDockerHost())


### PR DESCRIPTION
0.0.13 added per-registry auth, which is used in two ways..

- by the lifecycle binaries in the phase containers via the CNB_REGISTRY_AUTH var constructed from the config. 
- by docker-java when it interacts with docker/podman, eg, to pull the builder,run images

The first was functional, the second was missing the call to add the auth config to the docker-java client instance. 

This PR adds the missing invocation, and adds additional log statements to help debug auth issues next time ;)