### PR TITLE
podman windows and host/socket updates

### DIFF
--- a/client/src/main/java/dev/snowdrop/buildpack/BuildpackBuild.java
+++ b/client/src/main/java/dev/snowdrop/buildpack/BuildpackBuild.java
@@ -68,15 +68,38 @@ public class BuildpackBuild {
 
     }
 
+    private void verifyContainerRuntime(DockerConfig dc) {
+        //check if docker client is available
+        if(dc.getDockerClient() == null){
+            throw new BuildpackException("Unable to connect to container runtime, no docker client available", new IllegalStateException());
+        }
+        //check if docker host is available
+        if(dc.getHostAndSocketConfig().getSocket().isEmpty()){
+            throw new BuildpackException("Unable to connect to container runtime, no docker host available", new IllegalStateException());
+        }
+        //check if docker socket is available
+        if(dc.getHostAndSocketConfig().getSocket().isEmpty()){
+            throw new BuildpackException("Unable to connect to container runtime, no docker socket available", new IllegalStateException());
+        }
+        log.info("Verifying connection to container runtime...");
+        try{
+            dc.getDockerClient().pingCmd().exec();
+        }catch(Exception e){
+            throw new BuildpackException("Unable to verify containe runtime settings", e);
+        }
+    }
+
     public int build(){
 
         log.info("Buildpack build requested with config: \n"+
                  " - builder "+config.getBuilderImage().getCanonicalReference()+"\n"+
                  " - output "+config.getOutputImage().getReference()+"\n"+
                  " - logLevel "+config.getLogConfig().getLogLevel()+"\n"+
-                 " - dockerHost "+config.getDockerConfig().getDockerHost()+"\n"+
-                 " - dockerSocket "+config.getDockerConfig().getDockerSocket()+"\n"+
+                 " - dockerHost "+config.getDockerConfig().getHostAndSocketConfig().getHost().get()+"\n"+
+                 " - dockerSocket "+config.getDockerConfig().getHostAndSocketConfig().getSocket().get()+"\n"+
                  " - useDaemon "+config.getDockerConfig().getUseDaemon());
+
+        verifyContainerRuntime(config.getDockerConfig());
 
         log.info("Pulling Builder image");
 

--- a/client/src/main/java/dev/snowdrop/buildpack/BuildpackBuild.java
+++ b/client/src/main/java/dev/snowdrop/buildpack/BuildpackBuild.java
@@ -74,11 +74,11 @@ public class BuildpackBuild {
             throw new BuildpackException("Unable to connect to container runtime, no docker client available", new IllegalStateException());
         }
         //check if docker host is available
-        if(dc.getHostAndSocketConfig().getSocket().isEmpty()){
+        if(dc.getHostAndSocketConfig().getHost().get().isEmpty()){
             throw new BuildpackException("Unable to connect to container runtime, no docker host available", new IllegalStateException());
         }
         //check if docker socket is available
-        if(dc.getHostAndSocketConfig().getSocket().isEmpty()){
+        if(dc.getHostAndSocketConfig().getSocket().get().isEmpty()){
             throw new BuildpackException("Unable to connect to container runtime, no docker socket available", new IllegalStateException());
         }
         log.info("Verifying connection to container runtime...");

--- a/client/src/main/java/dev/snowdrop/buildpack/config/DockerConfig.java
+++ b/client/src/main/java/dev/snowdrop/buildpack/config/DockerConfig.java
@@ -3,15 +3,19 @@ package dev.snowdrop.buildpack.config;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.github.dockerjava.api.DockerClient;
 
 import dev.snowdrop.buildpack.BuildpackException;
 import dev.snowdrop.buildpack.docker.DockerClientUtils;
-import dev.snowdrop.buildpack.docker.DockerClientUtils.HostAndSocket;
 import io.sundr.builder.annotations.Buildable;
 
 @Buildable(generateBuilderPackage=true, builderPackage="dev.snowdrop.buildpack.builder")
 public class DockerConfig {
+    private static final Logger log = LoggerFactory.getLogger(DockerConfig.class);
+
     public static DockerConfigBuilder builder() {
         return new DockerConfigBuilder();
     }
@@ -27,8 +31,7 @@ public class DockerConfig {
     private Integer pullRetryCount;
     private Integer pullRetryIncreaseSeconds;
     private PullPolicy pullPolicy;
-    private String dockerHost;
-    private String dockerSocket;
+    private HostAndSocketConfig hostAndSocketConfig;
     private String dockerNetwork;
     private Boolean useDaemon;
     private DockerClient dockerClient;
@@ -39,13 +42,15 @@ public class DockerConfig {
         Integer pullRetryCount,
         Integer pullRetryIncreaseSeconds,
         PullPolicy pullPolicy,
-        String dockerHost, 
-        String dockerSocket,
+        HostAndSocketConfig hostAndSocketConfig,
         String dockerNetwork,
         Boolean useDaemon, 
         DockerClient dockerClient,
         List<RegistryAuthConfig> authConfigs
     ){
+        log.debug("DockerConfig: pullTimeoutSeconds={}, pullRetryCount={}, pullRetryIncreaseSeconds={}, pullPolicy={}, hostAndSocketConfig={}, dockerNetwork={}, useDaemon={}", 
+            pullTimeoutSeconds, pullRetryCount, pullRetryIncreaseSeconds, pullPolicy, hostAndSocketConfig, dockerNetwork, useDaemon);  
+
         this.pullTimeoutSeconds = pullTimeoutSeconds != null ? Integer.max(0,pullTimeoutSeconds) : DEFAULT_PULL_TIMEOUT;
         this.pullRetryCount = pullRetryCount != null ? Integer.max(0,pullRetryCount) : DEFAULT_PULL_RETRY_COUNT;
         this.pullRetryIncreaseSeconds = pullRetryIncreaseSeconds != null ? Integer.max(0,pullRetryIncreaseSeconds) : DEFAULT_PULL_RETRY_INCREASE;
@@ -53,33 +58,16 @@ public class DockerConfig {
         this.dockerNetwork = dockerNetwork;
         this.useDaemon = useDaemon != null ? useDaemon : Boolean.TRUE; //default daemon to true for back compat.
 
-        //take config values, and determine values to use.. 
-        HostAndSocket hands = DockerClientUtils.probeContainerRuntime(new DockerClientUtils.HostAndSocket(dockerHost, dockerSocket));
-        this.dockerHost = hands.host;
-        this.dockerSocket = hands.socket;
+        //process host & socket passed, and probe runtime to fill in unset values.
+        setHostAndSocketConfig(hostAndSocketConfig);
 
         this.authConfigs = authConfigs == null ? new ArrayList<>() : authConfigs;
-
-        this.dockerClient = dockerClient != null ? dockerClient : DockerClientUtils.getDockerClient(hands, authConfigs);
-
-        try{
-            this.dockerClient.pingCmd().exec();
-        }catch(Exception e){
-            throw new BuildpackException("Unable to verify docker settings", e);
-        }
+        this.dockerClient = dockerClient;
+        
     }
 
-    public void setDockerHost(String dockerHost){
-        HostAndSocket hands = DockerClientUtils.probeContainerRuntime(new DockerClientUtils.HostAndSocket(dockerHost, this.dockerSocket));
-        this.dockerHost = hands.host;
-        this.dockerSocket = hands.socket;
-        this.dockerClient = dockerClient != null ? dockerClient : DockerClientUtils.getDockerClient(hands);        
-    }
-    public void setDockerSocket(String dockerSocket){
-        HostAndSocket hands = DockerClientUtils.probeContainerRuntime(new DockerClientUtils.HostAndSocket(this.dockerHost, dockerSocket));
-        this.dockerHost = hands.host;
-        this.dockerSocket = hands.socket;
-        this.dockerClient = dockerClient != null ? dockerClient : DockerClientUtils.getDockerClient(hands);
+    public void setHostAndSocketConfig(HostAndSocketConfig hostAndSocketConfig) {
+        this.hostAndSocketConfig = DockerClientUtils.probeContainerRuntime(hostAndSocketConfig);
     }
 
     public Integer getPullTimeoutSeconds(){
@@ -98,12 +86,8 @@ public class DockerConfig {
         return this.pullPolicy;
     }
 
-    public String getDockerHost(){
-        return this.dockerHost;
-    }
-
-    public String getDockerSocket(){
-        return this.dockerSocket;
+    public HostAndSocketConfig getHostAndSocketConfig(){
+        return this.hostAndSocketConfig;
     }
 
     public String getDockerNetwork(){
@@ -111,6 +95,7 @@ public class DockerConfig {
     }
 
     public DockerClient getDockerClient(){
+        this.dockerClient = this.dockerClient != null ? this.dockerClient : DockerClientUtils.getDockerClient(this.hostAndSocketConfig, this.authConfigs);
         return this.dockerClient;
     }
 

--- a/client/src/main/java/dev/snowdrop/buildpack/config/HostAndSocketConfig.java
+++ b/client/src/main/java/dev/snowdrop/buildpack/config/HostAndSocketConfig.java
@@ -1,0 +1,32 @@
+package dev.snowdrop.buildpack.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+
+import dev.snowdrop.buildpack.docker.DockerClientUtils;
+import io.sundr.builder.annotations.Buildable;
+
+@Buildable(generateBuilderPackage=true, builderPackage="dev.snowdrop.buildpack.builder")
+public class HostAndSocketConfig {
+    private String host;
+    private String socket;
+
+    public static HostAndSocketConfigBuilder builder() {
+        return new HostAndSocketConfigBuilder();
+    }   
+
+    public HostAndSocketConfig(String host,
+                               String socket) {
+        this.host = host;
+        this.socket = socket;
+    }
+
+    public Optional<String> getHost() {
+        return Optional.ofNullable(host);
+    }
+    public Optional<String> getSocket() {
+        return Optional.ofNullable(socket);
+    }
+}

--- a/client/src/main/java/dev/snowdrop/buildpack/docker/DockerClientUtils.java
+++ b/client/src/main/java/dev/snowdrop/buildpack/docker/DockerClientUtils.java
@@ -13,6 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import dev.snowdrop.buildpack.config.RegistryAuthConfig;
+import dev.snowdrop.buildpack.config.HostAndSocketConfig;
 import dev.snowdrop.buildpack.utils.OperatingSytem;
 
 import com.github.dockerjava.api.DockerClient;
@@ -34,7 +35,7 @@ public class DockerClientUtils {
     return getDockerClient(probeContainerRuntime(null));
   }
 
-  public static DockerClient getDockerClient(HostAndSocket runtimeInfo) {
+  public static DockerClient getDockerClient(HostAndSocketConfig runtimeInfo) {
     return getDockerClient(runtimeInfo, new ArrayList<RegistryAuthConfig>(){});
   }
 
@@ -42,16 +43,15 @@ public class DockerClientUtils {
    * Simple util to get a DockerClient for the platform. probably needs more work
    * for other platforms, and we may want a way to configure authentication etc.
    */
-  public static DockerClient getDockerClient(HostAndSocket runtimeInfo, List<RegistryAuthConfig> authConfigs) {
-    if (runtimeInfo == null || runtimeInfo.host == null || runtimeInfo.host.isEmpty() ||
-                               runtimeInfo.socket == null || runtimeInfo.socket.isEmpty()) {
+  public static DockerClient getDockerClient(HostAndSocketConfig runtimeInfo, List<RegistryAuthConfig> authConfigs) {
+    if(runtimeInfo == null || !runtimeInfo.getHost().isPresent() || !runtimeInfo.getSocket().isPresent()) {
       log.warn("Supplied host/socket was null, attempting to use auto-configured defaults");
       return getDockerClient(probeContainerRuntime(runtimeInfo), authConfigs);
     }
 
-    log.debug("Using dockerhost " + runtimeInfo.host);
+    log.debug("Using dockerhost " + runtimeInfo.getHost().get());
     DockerClientConfig config = DefaultDockerClientConfig.createDefaultConfigBuilder()
-        .withDockerHost(runtimeInfo.host)
+        .withDockerHost(runtimeInfo.getHost().get())
         .build();
 
     AuthDelegatingDockerClientConfig addcc = new AuthDelegatingDockerClientConfig(config);
@@ -67,55 +67,41 @@ public class DockerClientUtils {
     return dockerClient;
   }
 
-  public static class HostAndSocket {
-    public String host;
-    public String socket;
-    public HostAndSocket(String host, String socket){
-      this.host = host; this.socket = socket;
-    }
-    public HostAndSocket(String host){
-      this.host = host;
-      this.socket = null;
-    }
-  }
-
-  public static HostAndSocket probeContainerRuntime(HostAndSocket overrides) {
+  public static HostAndSocketConfig probeContainerRuntime(HostAndSocketConfig overrides) {
+    log.debug("Probing for container runtime... "+(overrides!=null ? "H:"+overrides.getHost()+" S:"+overrides.getSocket() : "no overrides"));
     if(overrides!=null){
       //if user has supplied both host & socket, we don't need to probe at all, use their values.
       //(using isEmpty as isBlank is jdk11 onwards)
-      if(overrides.host!=null && overrides.socket!=null && !overrides.host.isEmpty() && !overrides.socket.isEmpty()){
-        return overrides;
+      if(overrides.getHost().isPresent() && overrides.getSocket().isPresent()){
+        return new HostAndSocketConfig(overrides.getHost().get(),overrides.getSocket().get());  
       }
-
-      //sanitize blank/empty values to null. (also using isEmpty because isBlank is only from jdk11 onwards)
-      if(overrides.host!=null && overrides.host.isEmpty()){
-        overrides.host=null;
-      }
-      if(overrides.socket!=null && overrides.socket.isEmpty()){
-        overrides.socket=null;
-      }
-    }else{
-      //no overrides at all? make an empty one.
-      overrides = new HostAndSocket(null, null);
     }
 
     try{
       //configure the override values as Optionals.
-      Optional<String> dockerHost = Optional.ofNullable(overrides.host);
+      Optional<String> dockerHost = overrides==null ? Optional.empty() : overrides.getHost();
       //for dockerhost, if user override was null, try to honor the env var
       if(!dockerHost.isPresent()){
         dockerHost = Optional.ofNullable(System.getenv("DOCKER_HOST"));
       }
-      Optional<String> dockerSocket = Optional.ofNullable(overrides.socket);
+      Optional<String> dockerSocket = overrides==null ? Optional.empty() : overrides.getSocket();
+
+      //if we now have a host & socket, we are done.
+      if(dockerHost.isPresent() && dockerSocket.isPresent()){
+        log.debug("Using docker host "+dockerHost.get()+" and socket "+dockerSocket.get());
+        return new HostAndSocketConfig(dockerHost.get(),dockerSocket.get());
+      }
 
       //if dockerhost is specified, but docker socket is not, test if dockerhost is podman rootful,
       //and autoconfigure dockersocket.. otherwise invoking podman as the user may result in the 
       //user socket being selected for use with the rootful host, leading to failure.
       if ( dockerHost.isPresent() && !dockerSocket.isPresent() && 
          ( "unix:///var/run/podman/podman.sock".equals(dockerHost.get()) || "unix:///run/podman/podman.sock".equals(dockerHost.get()) )){
-        return new HostAndSocket(dockerHost.get(), dockerHost.get().substring("unix://".length()));
+        log.debug("Using podman rootful host "+dockerHost.get()+" and socket "+dockerHost.get().substring("unix://".length()));
+        return new HostAndSocketConfig(dockerHost.get(), dockerHost.get().substring("unix://".length()));
       }
 
+      //we are still missing a host or socket, so we need to probe for them.
       //try to obtain podman socket path.. 
       log.info("Testing for podman/docker...");
       DockerClientUtils.CmdResult cr = DockerClientUtils.start(PODMAN_SOCKET);
@@ -124,40 +110,41 @@ public class DockerClientUtils {
         String socket = cr.output.get(0);
         if(socket.startsWith("unix://")){
           socket = socket.substring("unix://".length());
-        }        
+        }
+        log.debug("Using derived socket path value of "+socket+" from podman cli invocation.");
         //podman was present, use podman to retrieve dockerhost value
         switch (OperatingSytem.getOperationSystem()) {
           case WIN:{
             DockerClientUtils.CmdResult scmd = DockerClientUtils.start(WIN_PODMAN_HOST);
             if(scmd.rc==0){
-              String fixedhost = scmd.output.get(0).replaceAll("\\", "/");
-              return new HostAndSocket(dockerHost.orElse(fixedhost), dockerSocket.orElse(cr.output.get(0)));
+              String fixedhost = scmd.output.get(0).replaceAll("\\\\", "/");
+              return new HostAndSocketConfig(dockerHost.orElse(fixedhost), dockerSocket.orElse(socket));
             }else{
               log.warn("Unable to obtain podman socket path from podman, using internal default");
-              return new HostAndSocket(dockerHost.orElse("npipe:////./pipe/docker_engine"),dockerSocket.orElse("/var/run/docker.sock"));
+              return new HostAndSocketConfig(dockerHost.orElse("npipe:////./pipe/docker_engine"),dockerSocket.orElse("/var/run/docker.sock"));
             }
           }
           case LINUX:{
             DockerClientUtils.CmdResult scmd = DockerClientUtils.start(LIN_PODMAN_HOST);
             if(scmd.rc==0){
-              return new HostAndSocket(dockerHost.orElse(scmd.output.get(0)), dockerSocket.orElse(socket));
+              return new HostAndSocketConfig(dockerHost.orElse(scmd.output.get(0)), dockerSocket.orElse(socket));
             }else{
               log.warn("Unable to obtain podman socket path from podman, using internal default");
-              return new HostAndSocket(dockerHost.orElse("unix:///var/run/podman.sock"), dockerSocket.orElse("/var/run/podman.sock"));
+              return new HostAndSocketConfig(dockerHost.orElse("unix:///var/run/podman.sock"), dockerSocket.orElse("/var/run/podman.sock"));
             }
           }
           case MAC:{
             DockerClientUtils.CmdResult scmd = DockerClientUtils.start(MAC_PODMAN_HOST);
             if(scmd.rc==0){
-              return new HostAndSocket(dockerHost.orElse(scmd.output.get(0)), dockerSocket.orElse(socket));
+              return new HostAndSocketConfig(dockerHost.orElse(scmd.output.get(0)), dockerSocket.orElse(socket));
             }else{
               log.warn("Unable to obtain podman socket path from podman, using internal default");
-              return new HostAndSocket(dockerHost.orElse("unix:///var/run/podman.sock"), dockerSocket.orElse("/var/run/podman.sock"));
+              return new HostAndSocketConfig(dockerHost.orElse("unix:///var/run/podman.sock"), dockerSocket.orElse("/var/run/podman.sock"));
             }
           }
           case UNKNOWN:{
             log.warn("Unable to identify Operating System, you may need to specify docker host / docker socket manually");
-            return new HostAndSocket(dockerHost.orElse("unix:///var/run/podman.sock"), dockerSocket.orElse("/var/run/podman.sock"));
+            return new HostAndSocketConfig(dockerHost.orElse("unix:///var/run/podman.sock"), dockerSocket.orElse("/var/run/podman.sock"));
           }
         }
       }else{
@@ -165,17 +152,17 @@ public class DockerClientUtils {
         //failed to obtain podman socket path, assuming docker.. 
         switch (OperatingSytem.getOperationSystem()) {
           case WIN:{
-            return new HostAndSocket(dockerHost.orElse("npipe:////./pipe/docker_engine"),dockerSocket.orElse("/var/run/docker.sock"));
+            return new HostAndSocketConfig(dockerHost.orElse("npipe:////./pipe/docker_engine"),dockerSocket.orElse("/var/run/docker.sock"));
           }
           case LINUX:{
-            return new HostAndSocket(dockerHost.orElse("unix:///var/run/docker.sock"), dockerSocket.orElse("/var/run/docker.sock"));
+            return new HostAndSocketConfig(dockerHost.orElse("unix:///var/run/docker.sock"), dockerSocket.orElse("/var/run/docker.sock"));
           }
           case MAC:{
-            return new HostAndSocket(dockerHost.orElse("unix:///var/run/docker.sock"), dockerSocket.orElse("/var/run/docker.sock"));
+            return new HostAndSocketConfig(dockerHost.orElse("unix:///var/run/docker.sock"), dockerSocket.orElse("/var/run/docker.sock"));
           }
           case UNKNOWN:{
             log.warn("Unable to identify Operating System, you may need to specify docker host / docker socket manually");
-            return new HostAndSocket(dockerHost.orElse("unix:///var/run/docker.sock"), dockerSocket.orElse("/var/run/docker.sock"));
+            return new HostAndSocketConfig(dockerHost.orElse("unix:///var/run/docker.sock"), dockerSocket.orElse("/var/run/docker.sock"));
           }
         }
       }

--- a/client/src/main/java/dev/snowdrop/buildpack/lifecycle/LifecyclePhaseFactory.java
+++ b/client/src/main/java/dev/snowdrop/buildpack/lifecycle/LifecyclePhaseFactory.java
@@ -93,7 +93,7 @@ public class LifecyclePhaseFactory {
                                     ));        
 
         if(dockerConfig.getUseDaemon())
-          binds.add(new VolumeBind(dockerConfig.getDockerSocket(), LifecyclePhaseFactory.DOCKER_SOCKET_PATH));
+          binds.add(new VolumeBind(dockerConfig.getHostAndSocketConfig().getSocket().get(), LifecyclePhaseFactory.DOCKER_SOCKET_PATH));
 
         // create a container using builderImage that will invoke the creator process
         String id = ContainerUtils.createContainer(dockerConfig.getDockerClient(), 
@@ -111,7 +111,7 @@ public class LifecyclePhaseFactory {
         log.debug("- mounted " + applicationVolume + " at " + WORKSPACE_VOL_PATH);
         log.debug("- mounted " + platformVolume + " at " + PLATFORM_VOL_PATH);
         if(dockerConfig.getUseDaemon())
-          log.debug("- mounted " + dockerConfig.getDockerSocket() + " at " + LifecyclePhaseFactory.DOCKER_SOCKET_PATH);
+          log.debug("- mounted " + dockerConfig.getHostAndSocketConfig().getSocket().get() + " at " + LifecyclePhaseFactory.DOCKER_SOCKET_PATH);
         log.debug("- mounted " + outputVolume + " at " + LAYERS_VOL_PATH);
         log.debug("- container id " + id);
         log.debug("- image reference "+builder.getImage().getCanonicalReference()); 

--- a/client/src/main/java/dev/snowdrop/buildpack/utils/FilePermissions.java
+++ b/client/src/main/java/dev/snowdrop/buildpack/utils/FilePermissions.java
@@ -14,7 +14,7 @@ public class FilePermissions {
                        (fp.contains(PosixFilePermission.GROUP_READ)?040:0) + (fp.contains(PosixFilePermission.GROUP_WRITE)?020:0) + (fp.contains(PosixFilePermission.GROUP_EXECUTE)?010:0) +
                        (fp.contains(PosixFilePermission.OTHERS_READ)?04:0) + (fp.contains(PosixFilePermission.OTHERS_WRITE)?02:0) + (fp.contains(PosixFilePermission.OTHERS_EXECUTE)?01:0);
             return mode;
-          }catch(IOException io){
+          }catch(IOException | UnsupportedOperationException e){
             //may not be able to process posixfileperms on all platforms, fall back to java io File perms, and set as owner & group
             return ( (file.canRead()?0400:0) + (file.canWrite()?0200:0) + (file.canExecute()?0100:0) )+
                    ( (file.canRead()?040:0) + (file.canWrite()?020:0) + (file.canExecute()?010:0) );                   

--- a/client/src/test/java/dev/snowdrop/buildpack/config/DockerConfigTest.java
+++ b/client/src/test/java/dev/snowdrop/buildpack/config/DockerConfigTest.java
@@ -21,6 +21,7 @@ import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.PingCmd;
 
 import dev.snowdrop.buildpack.docker.DockerClientUtils;
+import dev.snowdrop.buildpack.config.HostAndSocketConfig;
 
 @ExtendWith(MockitoExtension.class)
 public class DockerConfigTest {
@@ -31,14 +32,14 @@ public class DockerConfigTest {
         lenient().when(pingCmd.exec()).thenAnswer(Answers.RETURNS_DEFAULTS);
 
         try (MockedStatic<? extends DockerClientUtils> clientUtils = mockStatic(DockerClientUtils.class) ) {
-            DockerClientUtils.HostAndSocket hns = new DockerClientUtils.HostAndSocket("a","b");
+            HostAndSocketConfig hns = new HostAndSocketConfig("a","b");
             clientUtils.when(() -> DockerClientUtils.getDockerClient(eq(hns), any())).thenReturn(dockerClient);
             clientUtils.when(() -> DockerClientUtils.probeContainerRuntime(any())).thenReturn(hns);
 
-            DockerConfig dc1 = new DockerConfig(null, null, null, null, null, null, null, null, null, null);
+            DockerConfig dc1 = new DockerConfig(null, null, null, null, null, null, null, null, null);
             assertEquals(60, dc1.getPullTimeoutSeconds());
     
-            DockerConfig dc2 = new DockerConfig(245017, null, null, null, null, null, null, null, null, null);
+            DockerConfig dc2 = new DockerConfig(245017, null, null, null, null, null, null, null, null);
             assertEquals(dc2.getPullTimeoutSeconds(), 245017);
         }
     }
@@ -50,15 +51,15 @@ public class DockerConfigTest {
 
         try (MockedStatic<? extends DockerClientUtils> clientUtils = mockStatic(DockerClientUtils.class) ) {
             String dockerHost = "tcp://stilettos";
-            DockerClientUtils.HostAndSocket hns = new DockerClientUtils.HostAndSocket(dockerHost,"b");
+            HostAndSocketConfig hns = new HostAndSocketConfig(dockerHost,"b");
             clientUtils.when(() -> DockerClientUtils.getDockerClient(eq(hns), any())).thenReturn(dockerClient);
             clientUtils.when(() -> DockerClientUtils.probeContainerRuntime(any())).thenReturn(hns);
 
-            DockerConfig dc1 = new DockerConfig(null, null, null, null, null, null, null, null, null, null);
-            assertNotNull(dc1.getDockerHost());
+            DockerConfig dc1 = new DockerConfig(null, null, null, null, null, null, null, null, null);
+            assertNotNull(dc1.getHostAndSocketConfig().getHost().get());
     
-            DockerConfig dc2 = new DockerConfig(null, null, null, null, dockerHost, null, null, null, dockerClient, null);
-            assertEquals(dockerHost, dc2.getDockerHost());
+            DockerConfig dc2 = new DockerConfig(null, null, null, null, hns, null, null, dockerClient, null);
+            assertEquals(dockerHost, dc2.getHostAndSocketConfig().getHost().get());
         }
     }
 
@@ -69,15 +70,15 @@ public class DockerConfigTest {
 
         try (MockedStatic<? extends DockerClientUtils> clientUtils = mockStatic(DockerClientUtils.class) ) {
             String dockerSocket = "fish";
-            DockerClientUtils.HostAndSocket hns = new DockerClientUtils.HostAndSocket("a",dockerSocket);
+            HostAndSocketConfig hns = new HostAndSocketConfig("a",dockerSocket);
             clientUtils.when(() -> DockerClientUtils.getDockerClient(eq(hns), any())).thenReturn(dockerClient);
             clientUtils.when(() -> DockerClientUtils.probeContainerRuntime(any())).thenReturn(hns);
 
-            DockerConfig dc1 = new DockerConfig(null, null, null, null, null, null, null, null, null, null);
-            assertNotNull(dc1.getDockerSocket());
+            DockerConfig dc1 = new DockerConfig(null, null, null, null, null, null, null, null, null);
+            assertNotNull(dc1.getHostAndSocketConfig().getSocket().get());
     
-            DockerConfig dc4 = new DockerConfig(null, null, null, null, null, dockerSocket, null, null, null, null);
-            assertEquals(dockerSocket, dc4.getDockerSocket());
+            DockerConfig dc4 = new DockerConfig(null, null, null, null, hns, null, null, null, null);
+            assertEquals(dockerSocket, dc4.getHostAndSocketConfig().getSocket().get());
         }
     }
 
@@ -87,14 +88,14 @@ public class DockerConfigTest {
         lenient().when(pingCmd.exec()).thenAnswer(Answers.RETURNS_DEFAULTS);
 
         try (MockedStatic<? extends DockerClientUtils> clientUtils = mockStatic(DockerClientUtils.class) ) {
-            DockerClientUtils.HostAndSocket hns = new DockerClientUtils.HostAndSocket("a","b");
+            HostAndSocketConfig hns = new HostAndSocketConfig("a","b");
             clientUtils.when(() -> DockerClientUtils.getDockerClient(eq(hns), any())).thenReturn(dockerClient);
             clientUtils.when(() -> DockerClientUtils.probeContainerRuntime(any())).thenReturn(hns);
 
-            DockerConfig dc1 = new DockerConfig(null, null, null, null, null, null, "kitten", null, null, null);
+            DockerConfig dc1 = new DockerConfig(null, null, null, null, null, "kitten", null, null, null);
             assertEquals("kitten", dc1.getDockerNetwork());
     
-            DockerConfig dc2 = new DockerConfig(null, null, null, null, null, null, null, null, null, null);
+            DockerConfig dc2 = new DockerConfig(null, null, null, null, null, null, null, null, null);
             assertNull(dc2.getDockerNetwork());
         }        
     }
@@ -105,17 +106,17 @@ public class DockerConfigTest {
         lenient().when(pingCmd.exec()).thenAnswer(Answers.RETURNS_DEFAULTS);
 
         try (MockedStatic<? extends DockerClientUtils> clientUtils = mockStatic(DockerClientUtils.class) ) {
-            DockerClientUtils.HostAndSocket hns = new DockerClientUtils.HostAndSocket("a","b");
+            HostAndSocketConfig hns = new HostAndSocketConfig("a","b");
             clientUtils.when(() -> DockerClientUtils.getDockerClient(eq(hns), any())).thenReturn(dockerClient);
             clientUtils.when(() -> DockerClientUtils.probeContainerRuntime(any())).thenReturn(hns);
 
-            DockerConfig dc1 = new DockerConfig(null, null, null, null, null, null, null, null, null, null);
+            DockerConfig dc1 = new DockerConfig(null, null, null, null, null, null, null, null, null);
             assertTrue(dc1.getUseDaemon());
     
-            DockerConfig dc2 = new DockerConfig(null, null, null, null, null, null, null, true, null, null);
+            DockerConfig dc2 = new DockerConfig(null, null, null, null, null, null, true, null, null);
             assertTrue(dc2.getUseDaemon());
     
-            DockerConfig dc3 = new DockerConfig(null, null, null, null, null, null, null, false, null, null);
+            DockerConfig dc3 = new DockerConfig(null, null, null, null, null, null, false, null, null);
             assertFalse(dc3.getUseDaemon());
         }  
     }
@@ -126,15 +127,15 @@ public class DockerConfigTest {
         lenient().when(pingCmd.exec()).thenAnswer(Answers.RETURNS_DEFAULTS);
 
         try (MockedStatic<? extends DockerClientUtils> clientUtils = mockStatic(DockerClientUtils.class) ) {
-            DockerClientUtils.HostAndSocket hns = new DockerClientUtils.HostAndSocket("a","b");
+            HostAndSocketConfig hns = new HostAndSocketConfig("a","b");
             clientUtils.when(() -> DockerClientUtils.getDockerClient(eq(hns), any())).thenReturn(dockerClient);
             clientUtils.when(() -> DockerClientUtils.probeContainerRuntime(any())).thenReturn(hns);
 
-            DockerConfig dc1 = new DockerConfig(null, null, null, null, null, null, null, null, null, null);
+            DockerConfig dc1 = new DockerConfig(null, null, null, null, null, null, null, null, null);
             assertNotNull(dc1.getDockerClient());
         }
 
-        DockerConfig dc2 = new DockerConfig(null, null, null, null, null, null, null, null, dockerClient, null);
+        DockerConfig dc2 = new DockerConfig(null, null, null, null, null, null, null, dockerClient, null);
         assertEquals(dockerClient, dc2.getDockerClient());
     }
 
@@ -143,13 +144,13 @@ public class DockerConfigTest {
         lenient().when(dockerClient.pingCmd()).thenReturn(pingCmd);
         lenient().when(pingCmd.exec()).thenAnswer(Answers.RETURNS_DEFAULTS);
 
-        DockerConfig dc1 = new DockerConfig(null, null, null, null, null, null, null, null, dockerClient, null);
+        DockerConfig dc1 = new DockerConfig(null, null, null, null, null, null, null, dockerClient, null);
         assertEquals(DockerConfig.PullPolicy.IF_NOT_PRESENT, dc1.getPullPolicy());
 
-        DockerConfig dc2 = new DockerConfig(null, null, null, DockerConfig.PullPolicy.IF_NOT_PRESENT, null, null, null, null, dockerClient, null);
+        DockerConfig dc2 = new DockerConfig(null, null, null, DockerConfig.PullPolicy.IF_NOT_PRESENT, null, null, null, dockerClient, null);
         assertEquals(DockerConfig.PullPolicy.IF_NOT_PRESENT, dc2.getPullPolicy());
 
-        DockerConfig dc3 = new DockerConfig(null, null, null, DockerConfig.PullPolicy.ALWAYS, null, null, null, null, dockerClient, null);
+        DockerConfig dc3 = new DockerConfig(null, null, null, DockerConfig.PullPolicy.ALWAYS, null, null, null, dockerClient, null);
         assertEquals(DockerConfig.PullPolicy.ALWAYS, dc3.getPullPolicy());        
     }  
     
@@ -159,13 +160,13 @@ public class DockerConfigTest {
         lenient().when(dockerClient.pingCmd()).thenReturn(pingCmd);
         lenient().when(pingCmd.exec()).thenAnswer(Answers.RETURNS_DEFAULTS);
 
-        DockerConfig dc1 = new DockerConfig(null, null, null, null, null, null, null, null, dockerClient, null);
+        DockerConfig dc1 = new DockerConfig(null, null, null, null, null, null, null, dockerClient, null);
         assertEquals(3, dc1.getPullRetryCount());
 
-        DockerConfig dc2 = new DockerConfig(null, 5, null, null, null, null, null, null, dockerClient, null);
+        DockerConfig dc2 = new DockerConfig(null, 5, null, null, null, null, null, dockerClient, null);
         assertEquals(5, dc2.getPullRetryCount());
 
-        DockerConfig dc3 = new DockerConfig(null, 0, null, null, null, null, null, null, dockerClient, null);
+        DockerConfig dc3 = new DockerConfig(null, 0, null, null, null, null, null, dockerClient, null);
         assertEquals(0, dc3.getPullRetryCount());        
     }     
 }

--- a/client/src/test/java/dev/snowdrop/buildpack/docker/DockerClientUtilsTest.java
+++ b/client/src/test/java/dev/snowdrop/buildpack/docker/DockerClientUtilsTest.java
@@ -9,7 +9,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.github.dockerjava.api.DockerClient;
 
-import dev.snowdrop.buildpack.docker.DockerClientUtils.HostAndSocket;
+import dev.snowdrop.buildpack.config.HostAndSocketConfig;
 
 @ExtendWith(MockitoExtension.class)
 public class DockerClientUtilsTest {
@@ -18,10 +18,10 @@ public class DockerClientUtilsTest {
   void getDockerHost() {
     String val = System.getenv("DOCKER_HOST");
 
-    HostAndSocket result = DockerClientUtils.probeContainerRuntime(null);
+    HostAndSocketConfig result = DockerClientUtils.probeContainerRuntime(null);
 
     if (val != null) {
-      assertEquals(val, result.host);
+      assertEquals(val, result.getHost().get());
     }
 
     assertNotNull(result);


### PR DESCRIPTION
Reported via : https://github.com/quarkusio/quarkus/issues/47940

The cause was trying to use replaceAll to swap \ for /, and forgetting that replaceAll uses regex, so requires \\\\ not just \\ 

However, it should have been possible to work around the issue by specifying host/socket as arguments, and that failed, because the sequence of invocations creating the config still drove the autodetect logic. 

This moves the host/socket to a sub config object, ensuring they are set into the docker config object as a single operation. 

This a *breaking change* to the config api, as withDockerHost & withDockerSocket are removed, and callers should use withHostAndSocketConfig instead

Also contains minor tweaks to ensure if both overrides are present, the autodetect logic is skipped entirely. 