### PR TITLE
Updates for 0.14 / OSSRH / bugfixes

### DIFF
--- a/.github/workflows/multiplatform-registry-test.yml
+++ b/.github/workflows/multiplatform-registry-test.yml
@@ -14,41 +14,31 @@ jobs:
       # Each test is a different scenario, do not cancel running tests if one fails.
       fail-fast: false
       matrix:
-        # Define projects to test, don't use generated matrix, as will need projects appropriate for each jvm to test
-        projects: [
-           { project: "hello-spring",  java: "17", label: "M-P5-RL-J17-S", runner: "macos-13",       runtime: "podman5", root: "rootless" },
-           { project: "hello-spring",  java: "17", label: "U-P5-RL-J17-S", runner: "ubuntu-24.04",   runtime: "podman5", root: "rootless" },
-           { project: "hello-spring",  java: "17", label: "U-P4-RL-J17-S", runner: "ubuntu-24.04",   runtime: "podman4", root: "rootless" },
-           { project: "hello-spring",  java: "17", label: "M-P5-RF-J17-S", runner: "macos-13",       runtime: "podman5", root: "rootful" },
-           { project: "hello-spring",  java: "17", label: "U-P5-RF-J17-S", runner: "ubuntu-24.04",   runtime: "podman5", root: "rootful" },
-           { project: "hello-spring",  java: "17", label: "U-P4-RF-J17-S", runner: "ubuntu-24.04",   runtime: "podman4", root: "rootful" },
-           { project: "hello-spring",  java: "17", label: "U-D-RL-J17-S",  runner: "ubuntu-24.04",   runtime: "docker" },
-           { project: "hello-spring",  java: "17", label: "W-D-RL-J17-S",  runner: "windows-latest", runtime: "docker" },
-           { project: "hello-quarkus", java: "17", label: "M-P5-RL-J17-Q", runner: "macos-13",       runtime: "podman5", root: "rootless" },
-           { project: "hello-quarkus", java: "17", label: "U-P5-RL-J17-Q", runner: "ubuntu-24.04",   runtime: "podman5", root: "rootless" },
-           { project: "hello-quarkus", java: "17", label: "U-P4-RL-J17-Q", runner: "ubuntu-24.04",   runtime: "podman4", root: "rootless" },
-           { project: "hello-quarkus", java: "17", label: "M-P5-RF-J17-Q", runner: "macos-13",       runtime: "podman5", root: "rootful" },
-           { project: "hello-quarkus", java: "17", label: "U-P5-RF-J17-Q", runner: "ubuntu-24.04",   runtime: "podman5", root: "rootful" },
-           { project: "hello-quarkus", java: "17", label: "U-P4-RF-J17-Q", runner: "ubuntu-24.04",   runtime: "podman4", root: "rootful" },
-           { project: "hello-quarkus", java: "17", label: "U-D-RL-J17-Q",  runner: "ubuntu-24.04",   runtime: "docker" },
-           { project: "hello-spring",  java: "17", label: "W-D-RL-J17-Q",  runner: "windows-latest", runtime: "docker" },
-           { project: "hello-spring",  java: "21", label: "M-P5-RL-J21-S", runner: "macos-13",       runtime: "podman5", root: "rootless" },
-           { project: "hello-spring",  java: "21", label: "U-P5-RL-J21-S", runner: "ubuntu-24.04",   runtime: "podman5", root: "rootless" },
-           { project: "hello-spring",  java: "21", label: "U-P4-RL-J21-S", runner: "ubuntu-24.04",   runtime: "podman4", root: "rootless" },
-           { project: "hello-spring",  java: "21", label: "M-P5-RF-J21-S", runner: "macos-13",       runtime: "podman5", root: "rootful" },
-           { project: "hello-spring",  java: "21", label: "U-P5-RF-J21-S", runner: "ubuntu-24.04",   runtime: "podman5", root: "rootful" },
-           { project: "hello-spring",  java: "21", label: "U-P4-RF-J21-S", runner: "ubuntu-24.04",   runtime: "podman4", root: "rootful" },
-           { project: "hello-spring",  java: "21", label: "U-D-RL-J21-S",  runner: "ubuntu-24.04",   runtime: "docker" },
-           { project: "hello-spring",  java: "21", label: "W-D-RL-J21-S",  runner: "windows-latest", runtime: "docker" },
-           { project: "hello-quarkus", java: "21", label: "M-P5-RL-J21-Q", runner: "macos-13",       runtime: "podman5", root: "rootless" },
-           { project: "hello-quarkus", java: "21", label: "U-P5-RL-J21-Q", runner: "ubuntu-24.04",   runtime: "podman5", root: "rootless" },
-           { project: "hello-quarkus", java: "21", label: "U-P4-RL-J21-Q", runner: "ubuntu-24.04",   runtime: "podman4", root: "rootless" },
-           { project: "hello-quarkus", java: "21", label: "M-P5-RF-J21-Q", runner: "macos-13",       runtime: "podman5", root: "rootful" },
-           { project: "hello-quarkus", java: "21", label: "U-P5-RF-J21-Q", runner: "ubuntu-24.04",   runtime: "podman5", root: "rootful" },
-           { project: "hello-quarkus", java: "21", label: "U-P4-RF-J21-Q", runner: "ubuntu-24.04",   runtime: "podman4", root: "rootful" },
-           { project: "hello-quarkus", java: "21", label: "U-D-RL-J21-Q",  runner: "ubuntu-24.04",   runtime: "docker" },
-           { project: "hello-spring",  java: "21", label: "W-D-RL-J21-Q",  runner: "windows-latest", runtime: "docker" }
-        ]
+        projects:
+          - { project: "hello-spring",  java: "17", label: "U-P5-RL-J17-S", runner: "ubuntu-24.04",   runtime: "podman5", root: "rootless" }
+          - { project: "hello-spring",  java: "17", label: "U-P4-RL-J17-S", runner: "ubuntu-24.04",   runtime: "podman4", root: "rootless" }
+          - { project: "hello-spring",  java: "17", label: "U-P5-RF-J17-S", runner: "ubuntu-24.04",   runtime: "podman5", root: "rootful" }
+          - { project: "hello-spring",  java: "17", label: "U-P4-RF-J17-S", runner: "ubuntu-24.04",   runtime: "podman4", root: "rootful" }
+          - { project: "hello-spring",  java: "17", label: "U-D-RL-J17-S",  runner: "ubuntu-24.04",   runtime: "docker" }
+          - { project: "hello-spring",  java: "17", label: "W-D-RL-J17-S",  runner: "windows-latest", runtime: "docker" }
+          - { project: "hello-quarkus", java: "17", label: "U-P5-RL-J17-Q", runner: "ubuntu-24.04",   runtime: "podman5", root: "rootless" }
+          - { project: "hello-quarkus", java: "17", label: "U-P4-RL-J17-Q", runner: "ubuntu-24.04",   runtime: "podman4", root: "rootless" }
+          - { project: "hello-quarkus", java: "17", label: "U-P5-RF-J17-Q", runner: "ubuntu-24.04",   runtime: "podman5", root: "rootful" }
+          - { project: "hello-quarkus", java: "17", label: "U-P4-RF-J17-Q", runner: "ubuntu-24.04",   runtime: "podman4", root: "rootful" }
+          - { project: "hello-quarkus", java: "17", label: "U-D-RL-J17-Q",  runner: "ubuntu-24.04",   runtime: "docker" }
+          - { project: "hello-spring",  java: "17", label: "W-D-RL-J17-Q",  runner: "windows-latest", runtime: "docker" }
+          - { project: "hello-spring",  java: "21", label: "U-P5-RL-J21-S", runner: "ubuntu-24.04",   runtime: "podman5", root: "rootless" }
+          - { project: "hello-spring",  java: "21", label: "U-P4-RL-J21-S", runner: "ubuntu-24.04",   runtime: "podman4", root: "rootless" }
+          - { project: "hello-spring",  java: "21", label: "U-P5-RF-J21-S", runner: "ubuntu-24.04",   runtime: "podman5", root: "rootful" }
+          - { project: "hello-spring",  java: "21", label: "U-P4-RF-J21-S", runner: "ubuntu-24.04",   runtime: "podman4", root: "rootful" }
+          - { project: "hello-spring",  java: "21", label: "U-D-RL-J21-S",  runner: "ubuntu-24.04",   runtime: "docker" }
+          - { project: "hello-spring",  java: "21", label: "W-D-RL-J21-S",  runner: "windows-latest", runtime: "docker" }
+          - { project: "hello-quarkus", java: "21", label: "U-P5-RL-J21-Q", runner: "ubuntu-24.04",   runtime: "podman5", root: "rootless" }
+          - { project: "hello-quarkus", java: "21", label: "U-P4-RL-J21-Q", runner: "ubuntu-24.04",   runtime: "podman4", root: "rootless" }
+          - { project: "hello-quarkus", java: "21", label: "U-P5-RF-J21-Q", runner: "ubuntu-24.04",   runtime: "podman5", root: "rootful" }
+          - { project: "hello-quarkus", java: "21", label: "U-P4-RF-J21-Q", runner: "ubuntu-24.04",   runtime: "podman4", root: "rootful" }
+          - { project: "hello-quarkus", java: "21", label: "U-D-RL-J21-Q",  runner: "ubuntu-24.04",   runtime: "docker" }
+          - { project: "hello-spring",  java: "21", label: "W-D-RL-J21-Q",  runner: "windows-latest", runtime: "docker" }
 
     runs-on: [ "${{ matrix.projects.runner }}" ]
     # Keep name short, as github ui does not allow many characters to be displayed
@@ -68,26 +58,6 @@ jobs:
           large-packages: true
           docker-images: true
           swap-storage: false
-
-      # Install and configure podman for mac
-      - name: Podman5 Mac
-        if: matrix.projects.runner == 'macos-13' && matrix.projects.runtime == 'podman5'
-        run: |
-          echo "Installing Podman for Mac"
-          cd /tmp
-          wget -nv "https://github.com/containers/podman/releases/download/v5.3.1/podman-installer-macos-universal.pkg"
-          sudo installer -pkg /tmp/podman-installer-macos-universal.pkg -target /
-          export PATH=$PATH:/opt/podman/bin
-
-          # Add Podman to path for future steps.
-          echo "/opt/podman/bin" >> $GITHUB_PATH
-
-          # launch podman
-          podman machine init
-          podman machine start
-
-          # reconfigure timeouts inside podman vm to be compatible with java docker api
-          echo 'mkdir -p /etc/containers/containers.conf.d && printf "[engine]\nservice_timeout=91\n" > /etc/containers/containers.conf.d/service-timeout.conf && systemctl restart podman.socket' |  podman machine ssh --username root --
       
       # Configure podman for ubuntu
       - name: Podman4 Ubuntu
@@ -126,7 +96,7 @@ jobs:
           brew services restart podman
 
       - name: Podman Rootful (podman machine)
-        if: (matrix.projects.runner == 'macos-13' || matrix.projects.runner == 'windows-latest') && (matrix.projects.runtime == 'podman5' || matrix.projects.runtime == 'podman4') && matrix.projects.root == 'rootful'
+        if: matrix.projects.runner == 'windows-latest' && (matrix.projects.runtime == 'podman5' || matrix.projects.runtime == 'podman4') && matrix.projects.root == 'rootful'
         run: |
           podman system connection ls
           podman machine stop
@@ -185,7 +155,7 @@ jobs:
 
       # Install jbang (required to run tests)
       - name: Setup jbang (unix)
-        if: matrix.projects.runner == 'macos-13' || matrix.projects.runner == 'ubuntu-24.04'
+        if: matrix.projects.runner == 'ubuntu-24.04'
         run: |
           curl -Ls "https://sh.jbang.dev" | bash -s - app setup
 
@@ -228,7 +198,7 @@ jobs:
           
       # Build the matrix specificied project with the options configured.
       - name: Build test project (unix)
-        if: matrix.projects.runner == 'macos-13' || matrix.projects.runner == 'ubuntu-24.04'
+        if: matrix.projects.runner == 'ubuntu-24.04'
         run: |
           echo Setting up to build ${{ matrix.projects.project }} with ${{ matrix.projects.java-buildpack-lib-jitpack}} on ${{ matrix.projects.runner }}
           

--- a/.github/workflows/multiplatform-test.yml
+++ b/.github/workflows/multiplatform-test.yml
@@ -14,41 +14,31 @@ jobs:
       # Each test is a different scenario, do not cancel running tests if one fails.
       fail-fast: false
       matrix:
-        # Define projects to test, don't use generated matrix, as will need projects appropriate for each jvm to test
-        projects: [
-           { project: "hello-spring",  java: "17", label: "M-P5-RL-J17-S", runner: "macos-13",       runtime: "podman5", root: "rootless" },
-           { project: "hello-spring",  java: "17", label: "U-P5-RL-J17-S", runner: "ubuntu-24.04",   runtime: "podman5", root: "rootless" },
-           { project: "hello-spring",  java: "17", label: "U-P4-RL-J17-S", runner: "ubuntu-24.04",   runtime: "podman4", root: "rootless" },
-           { project: "hello-spring",  java: "17", label: "M-P5-RF-J17-S", runner: "macos-13",       runtime: "podman5", root: "rootful" },
-           { project: "hello-spring",  java: "17", label: "U-P5-RF-J17-S", runner: "ubuntu-24.04",   runtime: "podman5", root: "rootful" },
-           { project: "hello-spring",  java: "17", label: "U-P4-RF-J17-S", runner: "ubuntu-24.04",   runtime: "podman4", root: "rootful" },
-           { project: "hello-spring",  java: "17", label: "U-D-RL-J17-S",  runner: "ubuntu-24.04",   runtime: "docker" },
-           { project: "hello-spring",  java: "17", label: "W-D-RL-J17-S",  runner: "windows-latest", runtime: "docker" },
-           { project: "hello-quarkus", java: "17", label: "M-P5-RL-J17-Q", runner: "macos-13",       runtime: "podman5", root: "rootless" },
-           { project: "hello-quarkus", java: "17", label: "U-P5-RL-J17-Q", runner: "ubuntu-24.04",   runtime: "podman5", root: "rootless" },
-           { project: "hello-quarkus", java: "17", label: "U-P4-RL-J17-Q", runner: "ubuntu-24.04",   runtime: "podman4", root: "rootless" },
-           { project: "hello-quarkus", java: "17", label: "M-P5-RF-J17-Q", runner: "macos-13",       runtime: "podman5", root: "rootful" },
-           { project: "hello-quarkus", java: "17", label: "U-P5-RF-J17-Q", runner: "ubuntu-24.04",   runtime: "podman5", root: "rootful" },
-           { project: "hello-quarkus", java: "17", label: "U-P4-RF-J17-Q", runner: "ubuntu-24.04",   runtime: "podman4", root: "rootful" },
-           { project: "hello-quarkus", java: "17", label: "U-D-RL-J17-Q",  runner: "ubuntu-24.04",   runtime: "docker" },
-           { project: "hello-spring",  java: "17", label: "W-D-RL-J17-Q",  runner: "windows-latest", runtime: "docker" },
-           { project: "hello-spring",  java: "21", label: "M-P5-RL-J21-S", runner: "macos-13",       runtime: "podman5", root: "rootless" },
-           { project: "hello-spring",  java: "21", label: "U-P5-RL-J21-S", runner: "ubuntu-24.04",   runtime: "podman5", root: "rootless" },
-           { project: "hello-spring",  java: "21", label: "U-P4-RL-J21-S", runner: "ubuntu-24.04",   runtime: "podman4", root: "rootless" },
-           { project: "hello-spring",  java: "21", label: "M-P5-RF-J21-S", runner: "macos-13",       runtime: "podman5", root: "rootful" },
-           { project: "hello-spring",  java: "21", label: "U-P5-RF-J21-S", runner: "ubuntu-24.04",   runtime: "podman5", root: "rootful" },
-           { project: "hello-spring",  java: "21", label: "U-P4-RF-J21-S", runner: "ubuntu-24.04",   runtime: "podman4", root: "rootful" },
-           { project: "hello-spring",  java: "21", label: "U-D-RL-J21-S",  runner: "ubuntu-24.04",   runtime: "docker" },
-           { project: "hello-spring",  java: "21", label: "W-D-RL-J21-S",  runner: "windows-latest", runtime: "docker" },
-           { project: "hello-quarkus", java: "21", label: "M-P5-RL-J21-Q", runner: "macos-13",       runtime: "podman5", root: "rootless" },
-           { project: "hello-quarkus", java: "21", label: "U-P5-RL-J21-Q", runner: "ubuntu-24.04",   runtime: "podman5", root: "rootless" },
-           { project: "hello-quarkus", java: "21", label: "U-P4-RL-J21-Q", runner: "ubuntu-24.04",   runtime: "podman4", root: "rootless" },
-           { project: "hello-quarkus", java: "21", label: "M-P5-RF-J21-Q", runner: "macos-13",       runtime: "podman5", root: "rootful" },
-           { project: "hello-quarkus", java: "21", label: "U-P5-RF-J21-Q", runner: "ubuntu-24.04",   runtime: "podman5", root: "rootful" },
-           { project: "hello-quarkus", java: "21", label: "U-P4-RF-J21-Q", runner: "ubuntu-24.04",   runtime: "podman4", root: "rootful" },
-           { project: "hello-quarkus", java: "21", label: "U-D-RL-J21-Q",  runner: "ubuntu-24.04",   runtime: "docker" },
-           { project: "hello-spring",  java: "21", label: "W-D-RL-J21-Q",  runner: "windows-latest", runtime: "docker" }
-        ]
+        projects:
+          - { project: "hello-spring",  java: "17", label: "U-P5-RL-J17-S", runner: "ubuntu-24.04",   runtime: "podman5", root: "rootless" }
+          - { project: "hello-spring",  java: "17", label: "U-P4-RL-J17-S", runner: "ubuntu-24.04",   runtime: "podman4", root: "rootless" }
+          - { project: "hello-spring",  java: "17", label: "U-P5-RF-J17-S", runner: "ubuntu-24.04",   runtime: "podman5", root: "rootful" }
+          - { project: "hello-spring",  java: "17", label: "U-P4-RF-J17-S", runner: "ubuntu-24.04",   runtime: "podman4", root: "rootful" }
+          - { project: "hello-spring",  java: "17", label: "U-D-RL-J17-S",  runner: "ubuntu-24.04",   runtime: "docker" }
+          - { project: "hello-spring",  java: "17", label: "W-D-RL-J17-S",  runner: "windows-latest", runtime: "docker" }
+          - { project: "hello-quarkus", java: "17", label: "U-P5-RL-J17-Q", runner: "ubuntu-24.04",   runtime: "podman5", root: "rootless" }
+          - { project: "hello-quarkus", java: "17", label: "U-P4-RL-J17-Q", runner: "ubuntu-24.04",   runtime: "podman4", root: "rootless" }
+          - { project: "hello-quarkus", java: "17", label: "U-P5-RF-J17-Q", runner: "ubuntu-24.04",   runtime: "podman5", root: "rootful" }
+          - { project: "hello-quarkus", java: "17", label: "U-P4-RF-J17-Q", runner: "ubuntu-24.04",   runtime: "podman4", root: "rootful" }
+          - { project: "hello-quarkus", java: "17", label: "U-D-RL-J17-Q",  runner: "ubuntu-24.04",   runtime: "docker" }
+          - { project: "hello-spring",  java: "17", label: "W-D-RL-J17-Q",  runner: "windows-latest", runtime: "docker" }
+          - { project: "hello-spring",  java: "21", label: "U-P5-RL-J21-S", runner: "ubuntu-24.04",   runtime: "podman5", root: "rootless" }
+          - { project: "hello-spring",  java: "21", label: "U-P4-RL-J21-S", runner: "ubuntu-24.04",   runtime: "podman4", root: "rootless" }
+          - { project: "hello-spring",  java: "21", label: "U-P5-RF-J21-S", runner: "ubuntu-24.04",   runtime: "podman5", root: "rootful" }
+          - { project: "hello-spring",  java: "21", label: "U-P4-RF-J21-S", runner: "ubuntu-24.04",   runtime: "podman4", root: "rootful" }
+          - { project: "hello-spring",  java: "21", label: "U-D-RL-J21-S",  runner: "ubuntu-24.04",   runtime: "docker" }
+          - { project: "hello-spring",  java: "21", label: "W-D-RL-J21-S",  runner: "windows-latest", runtime: "docker" }
+          - { project: "hello-quarkus", java: "21", label: "U-P5-RL-J21-Q", runner: "ubuntu-24.04",   runtime: "podman5", root: "rootless" }
+          - { project: "hello-quarkus", java: "21", label: "U-P4-RL-J21-Q", runner: "ubuntu-24.04",   runtime: "podman4", root: "rootless" }
+          - { project: "hello-quarkus", java: "21", label: "U-P5-RF-J21-Q", runner: "ubuntu-24.04",   runtime: "podman5", root: "rootful" }
+          - { project: "hello-quarkus", java: "21", label: "U-P4-RF-J21-Q", runner: "ubuntu-24.04",   runtime: "podman4", root: "rootful" }
+          - { project: "hello-quarkus", java: "21", label: "U-D-RL-J21-Q",  runner: "ubuntu-24.04",   runtime: "docker" }
+          - { project: "hello-spring",  java: "21", label: "W-D-RL-J21-Q",  runner: "windows-latest", runtime: "docker" }
 
     runs-on: [ "${{ matrix.projects.runner }}" ]
     # Keep name short, as github ui does not allow many characters to be displayed
@@ -68,26 +58,6 @@ jobs:
           large-packages: true
           docker-images: true
           swap-storage: false
-
-      # Install and configure podman for mac
-      - name: Podman5 Mac
-        if: matrix.projects.runner == 'macos-13' && matrix.projects.runtime == 'podman5'
-        run: |
-          echo "Installing Podman for Mac"
-          cd /tmp
-          wget -nv "https://github.com/containers/podman/releases/download/v5.3.1/podman-installer-macos-universal.pkg"
-          sudo installer -pkg /tmp/podman-installer-macos-universal.pkg -target /
-          export PATH=$PATH:/opt/podman/bin
-
-          # Add Podman to path for future steps.
-          echo "/opt/podman/bin" >> $GITHUB_PATH
-
-          # launch podman
-          podman machine init
-          podman machine start
-
-          # reconfigure timeouts inside podman vm to be compatible with java docker api
-          echo 'mkdir -p /etc/containers/containers.conf.d && printf "[engine]\nservice_timeout=91\n" > /etc/containers/containers.conf.d/service-timeout.conf && systemctl restart podman.socket' |  podman machine ssh --username root --
       
       # Configure podman for ubuntu
       - name: Podman4 Ubuntu
@@ -126,7 +96,7 @@ jobs:
           brew services restart podman
 
       - name: Podman Rootful (podman machine)
-        if: (matrix.projects.runner == 'macos-13' || matrix.projects.runner == 'windows-latest') && (matrix.projects.runtime == 'podman5' || matrix.projects.runtime == 'podman4') && matrix.projects.root == 'rootful'
+        if: matrix.projects.runner == 'windows-latest' && (matrix.projects.runtime == 'podman5' || matrix.projects.runtime == 'podman4') && matrix.projects.root == 'rootful'
         run: |
           podman system connection ls
           podman machine stop
@@ -185,7 +155,7 @@ jobs:
 
       # Install jbang (required to run tests)
       - name: Setup jbang (unix)
-        if: matrix.projects.runner == 'macos-13' || matrix.projects.runner == 'ubuntu-24.04'
+        if: matrix.projects.runner == 'ubuntu-24.04'
         run: |
           curl -Ls "https://sh.jbang.dev" | bash -s - app setup
 
@@ -230,7 +200,7 @@ jobs:
           
       # Build the matrix specificied project with the options configured.
       - name: Build test project (unix)
-        if: matrix.projects.runner == 'macos-13' || matrix.projects.runner == 'ubuntu-24.04'
+        if: matrix.projects.runner == 'ubuntu-24.04'
         run: |
           echo Setting up to build ${{ matrix.projects.project }} with ${{ matrix.projects.java-buildpack-lib-jitpack}} on ${{ matrix.projects.runner }}
           

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,14 +31,14 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
           cache: 'maven'
-          server-id: oss-sonatype-staging
-          server-username: OSS_SONATYPE_USERNAME
-          server-password: OSS_SONATYPE_PASSWORD
+          server-id: central
+          server-username: MAVEN_USERNAME # Sonatype "snowdrop-team" usertoken: username
+          server-password: MAVEN_PASSWORD # Sonatype "snowdrop-team" usertoken: password
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
@@ -61,8 +61,8 @@ jobs:
           mvn -B release:prepare -Prelease -Darguments="-DskipTests" -DreleaseVersion=${{steps.metadata.outputs.current-version}} -DdevelopmentVersion=${{steps.metadata.outputs.next-version}}
           mvn -B release:perform -Darguments="-DperformRelease -DskipTests" -DperformRelease -Prelease
         env:
-          OSS_SONATYPE_USERNAME: ${{ secrets.OSS_SONATYPE_USERNAME }}
-          OSS_SONATYPE_PASSWORD: ${{ secrets.OSS_SONATYPE_PASSWORD }}
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
       - name: Set dev version in the samples and readme
         run: |

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Prototype of a simple buildpack (https://buildpacks.io/) client for java.
 This project represents a simple implementation of the buildpack platform spec, 
 and can be used to build projects using specified buildpacks. 
 
-This project implements up to version 0.10 of the buildpack platform spec, and should
-work with builders requesting from 0.4 through to 0.10. 0.12 is available but experimental.
+This project implements up to version 0.14 of the buildpack platform spec, and should
+work with builders requesting from 0.4 through to 0.14.
 
 A fluent interface is provided to allow creation & configuration
 of the build to be performed. 

--- a/client/src/main/java/dev/snowdrop/buildpack/BuilderImage.java
+++ b/client/src/main/java/dev/snowdrop/buildpack/BuilderImage.java
@@ -87,14 +87,14 @@ public class BuilderImage {
             userId = Integer.valueOf(pc.getEnvironment().get("CNB_USER_ID")); 
         }
         if(pc.getEnvironment().containsKey("CNB_GROUP_ID")) { 
-            userId = Integer.valueOf(pc.getEnvironment().get("CNB_GROUP_ID")); 
+            groupId = Integer.valueOf(pc.getEnvironment().get("CNB_GROUP_ID")); 
         }
 
         String xtnLayers = ii.labels.get("io.buildpacks.extension.layers");
         //if xtnLayers is absent, or is just the empty json {}, there are no extensions.
         if(xtnLayers!=null && !xtnLayers.isEmpty()){
             xtnLayers = xtnLayers.trim();
-            xtnLayers.replaceAll("\\\\w", "");
+            xtnLayers = xtnLayers.replaceAll("\\\\w", "");
             if(xtnLayers.equals("{}")){
                 xtnLayers = null;
             }

--- a/client/src/main/java/dev/snowdrop/buildpack/BuildpackBuild.java
+++ b/client/src/main/java/dev/snowdrop/buildpack/BuildpackBuild.java
@@ -21,7 +21,7 @@ public class BuildpackBuild {
     private static final Logger log = LoggerFactory.getLogger(BuildpackBuild.class);
 
     //platforms stored in order of preference.
-    private final List<String> supportedPlatformLevels =Stream.of("0.12", "0.11", "0.10", "0.9", "0.8", "0.7", "0.6", "0.5", "0.4").collect(Collectors.toCollection(ArrayList::new));
+    private final List<String> supportedPlatformLevels =Stream.of("0.14", "0.13", "0.12", "0.11", "0.10", "0.9", "0.8", "0.7", "0.6", "0.5", "0.4").collect(Collectors.toCollection(ArrayList::new));
     //default platform level, used if not overridden
     public final String DEFAULT_PLATFORM_LEVEL = supportedPlatformLevels.get(0);
 

--- a/client/src/main/java/dev/snowdrop/buildpack/docker/BuildContainerUtils.java
+++ b/client/src/main/java/dev/snowdrop/buildpack/docker/BuildContainerUtils.java
@@ -61,7 +61,7 @@ public class BuildContainerUtils {
 
     private static void populateMountPointDirs(DockerClient dc, String targetContainerId, int uid, int gid, List<String> dirs){
         try (PipedInputStream in = new PipedInputStream(4096); PipedOutputStream out = new PipedOutputStream(in)) {
-            AtomicReference<Exception> writerException = new AtomicReference<>();
+            AtomicReference<Exception> cachedException = new AtomicReference<>();
 
             Runnable writer = new Runnable() {
                 @Override
@@ -78,7 +78,7 @@ public class BuildContainerUtils {
                             tout.closeArchiveEntry();
                         } 
                     } catch (Exception e) {
-                        writerException.set(e);
+                        cachedException.set(e);
                     }
                 } 
             };
@@ -86,7 +86,11 @@ public class BuildContainerUtils {
             Runnable reader = new Runnable() {
                 @Override
                 public void run() {
-                dc.copyArchiveToContainerCmd(targetContainerId).withRemotePath("/").withTarInputStream(in).exec();
+                    try {
+                        dc.copyArchiveToContainerCmd(targetContainerId).withRemotePath("/").withTarInputStream(in).exec();
+                    } catch (Exception e) {
+                        cachedException.set(e);
+                    }
                 }
             };
 
@@ -101,10 +105,10 @@ public class BuildContainerUtils {
                 throw BuildpackException.launderThrowable(ie);
             }
 
-            // did the write thread complete without issues? if not, bubble the cause.
-            Exception wio = writerException.get();
-            if (wio != null) {
-                throw BuildpackException.launderThrowable(wio);
+            // did either thread complete with issues? if so, bubble the cause.
+            Exception ex = cachedException.get();
+            if (ex != null) {
+                throw BuildpackException.launderThrowable(ex);
             }
         } catch (IOException e) {
             throw BuildpackException.launderThrowable(e);

--- a/client/src/main/java/dev/snowdrop/buildpack/docker/ContainerUtils.java
+++ b/client/src/main/java/dev/snowdrop/buildpack/docker/ContainerUtils.java
@@ -40,10 +40,8 @@ import com.github.dockerjava.api.model.Volume;
 import dev.snowdrop.buildpack.BuildpackException;
 import dev.snowdrop.buildpack.docker.ContainerEntry.DataSupplier;
 
-
 public class ContainerUtils {
   private static final Logger log = LoggerFactory.getLogger(ContainerUtils.class);
-
 
   public static String createContainer(DockerClient dc, String imageReference, VolumeBind... volumes) {
     return createContainer(dc, imageReference, null, volumes);
@@ -55,12 +53,12 @@ public class ContainerUtils {
 
   public static String createContainer(DockerClient dc, String imageReference, List<String> command,
       VolumeBind... volumes) {
-        return createContainer(dc, imageReference, command, 0, null, null, null, volumes);
+    return createContainer(dc, imageReference, command, 0, null, null, null, volumes);
   }
 
   public static String createContainer(DockerClient dc, String imageReference, List<String> command,
-        Integer runAsId, Map<String,String> env, String securityOpts, String network,
-        List<VolumeBind> volumes) {
+      Integer runAsId, Map<String, String> env, String securityOpts, String network,
+      List<VolumeBind> volumes) {
 
     CreateContainerCmd ccc = dc.createContainerCmd(imageReference);
     if (volumes != null) {
@@ -71,16 +69,15 @@ public class ContainerUtils {
       }
 
       ccc.getHostConfig().withBinds(binds);
-    }  
+    }
 
-    return createContainerInternal(dc,imageReference,command,runAsId,env,securityOpts,network,ccc);
+    return createContainerInternal(dc, imageReference, command, runAsId, env, securityOpts, network, ccc);
   }
 
   public static String createContainer(DockerClient dc, String imageReference, List<String> command,
-        Integer runAsId, Map<String,String> env, String securityOpts, String network,
-        VolumeBind... volumes) {
+      Integer runAsId, Map<String, String> env, String securityOpts, String network,
+      VolumeBind... volumes) {
 
-          
     CreateContainerCmd ccc = dc.createContainerCmd(imageReference);
     if (volumes != null) {
       List<Bind> binds = new ArrayList<>();
@@ -91,22 +88,22 @@ public class ContainerUtils {
       ccc.getHostConfig().withBinds(binds);
     }
 
-    return createContainerInternal(dc,imageReference,command,runAsId,env,securityOpts,network,ccc);
+    return createContainerInternal(dc, imageReference, command, runAsId, env, securityOpts, network, ccc);
   }
 
   private static String createContainerInternal(DockerClient dc, String imageReference, List<String> command,
-        Integer runAsId, Map<String,String> env, String securityOpts, String network, CreateContainerCmd ccc) {
+      Integer runAsId, Map<String, String> env, String securityOpts, String network, CreateContainerCmd ccc) {
 
-    if(runAsId!=null){
-        ccc.withUser(""+runAsId);
-    }
-    
-    if(env!=null) {
-      ccc.withEnv( env.entrySet().stream().map(e -> e.getKey()+"="+e.getValue()).collect(Collectors.toList()));
+    if (runAsId != null) {
+      ccc.withUser("" + runAsId);
     }
 
-    if(securityOpts!=null){
-      ccc.withHostConfig(ccc.getHostConfig().withSecurityOpts(Collections.singletonList(securityOpts)));  
+    if (env != null) {
+      ccc.withEnv(env.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue()).collect(Collectors.toList()));
+    }
+
+    if (securityOpts != null) {
+      ccc.withHostConfig(ccc.getHostConfig().withSecurityOpts(Collections.singletonList(securityOpts)));
     }
 
     if (command != null) {
@@ -114,8 +111,8 @@ public class ContainerUtils {
       ccc.withEntrypoint("");
     }
 
-    if (network!=null){
-       ccc.withHostConfig(ccc.getHostConfig().withNetworkMode(network));
+    if (network != null) {
+      ccc.withHostConfig(ccc.getHostConfig().withNetworkMode(network));
     }
 
     CreateContainerResponse ccr = ccc.exec();
@@ -125,28 +122,31 @@ public class ContainerUtils {
 
   public static String commitContainer(DockerClient dc, String containerId) {
     return dc.commitCmd(containerId).exec();
-  }  
+  }
 
   public static void removeContainer(DockerClient dc, String containerId) {
     dc.removeContainerCmd(containerId).withForce(true).exec();
   }
 
   public static void addContentToContainer(DockerClient dc, String containerId, List<ContainerEntry> entries) {
-    addContentToContainer(dc, containerId, entries != null ? entries.toArray(new ContainerEntry[entries.size()]) : new ContainerEntry[0]);
+    addContentToContainer(dc, containerId,
+        entries != null ? entries.toArray(new ContainerEntry[entries.size()]) : new ContainerEntry[0]);
   }
-  
+
   public static void addContentToContainer(DockerClient dc, String containerId, ContainerEntry... entries) {
     addContentToContainer(dc, containerId, "", null, null, entries);
   }
 
   public static void addContentToContainer(DockerClient dc, String containerId, String pathInContainer, Integer userId,
       Integer groupId, File content) {
-    addContentToContainer(dc, containerId, pathInContainer, userId, groupId, new FileContent("", content).getContainerEntries());
+    addContentToContainer(dc, containerId, pathInContainer, userId, groupId,
+        new FileContent("", content).getContainerEntries());
   }
 
   public static void addContentToContainer(DockerClient dc, String containerId, String pathInContainer, Integer userId,
       Integer groupId, String name, Integer mode, String content) {
-    addContentToContainer(dc, containerId, pathInContainer, userId, groupId, new StringContent(name, mode, content).getContainerEntries());
+    addContentToContainer(dc, containerId, pathInContainer, userId, groupId,
+        new StringContent(name, mode, content).getContainerEntries());
   }
 
   /**
@@ -164,13 +164,13 @@ public class ContainerUtils {
         if (unknown) {
           // add parents of this FIRST
           addParents(tout, seenDirs, uid, gid, parent);
-          
-          log.debug("adding "+parent+"/ to tar");
+
+          log.debug("adding " + parent + "/ to tar");
           // and then add this =)
           TarArchiveEntry tae = new TarArchiveEntry(parent + "/");
           tae.setSize(0);
           tae.setUserId(uid);
-          tae.setGroupId(gid);     
+          tae.setGroupId(gid);
           tae.setMode(TarArchiveEntry.DEFAULT_DIR_MODE);
           tout.putArchiveEntry(tae);
           tout.closeArchiveEntry();
@@ -184,13 +184,16 @@ public class ContainerUtils {
   /**
    * Adds content to the container, with specified uid/gid
    */
-  public static void addContentToContainer(DockerClient dc, String containerId, String pathInContainer, Integer userId, Integer groupId, List<ContainerEntry> entries) {
-    addContentToContainer(dc, containerId, pathInContainer, userId, groupId, entries != null ? entries.toArray(new ContainerEntry[entries.size()]) : new ContainerEntry[0]);
+  public static void addContentToContainer(DockerClient dc, String containerId, String pathInContainer, Integer userId,
+      Integer groupId, List<ContainerEntry> entries) {
+    addContentToContainer(dc, containerId, pathInContainer, userId, groupId,
+        entries != null ? entries.toArray(new ContainerEntry[entries.size()]) : new ContainerEntry[0]);
   }
 
-  public static void addContentToContainer(DockerClient dc, String containerId, String pathInContainer, Integer userId, Integer groupId, ContainerEntry... entries) {
+  public static void addContentToContainer(DockerClient dc, String containerId, String pathInContainer, Integer userId,
+      Integer groupId, ContainerEntry... entries) {
 
-    log.debug("Adding to container "+containerId+" pathInContainer "+pathInContainer);
+    log.debug("Adding to container " + containerId + " pathInContainer " + pathInContainer);
 
     Set<String> seenDirs = new HashSet<>();
     // Don't add entry for "/", causes issues with tar format.
@@ -211,92 +214,93 @@ public class ContainerUtils {
       Runnable writer = new Runnable() {
         @Override
         public void run() {
-          try (TarArchiveOutputStream tout = new TarArchiveOutputStream(new GZIPOutputStream(new BufferedOutputStream(out)));) {
+          try (TarArchiveOutputStream tout = new TarArchiveOutputStream(
+              new GZIPOutputStream(new BufferedOutputStream(out)));) {
             tout.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
             for (ContainerEntry ve : entries) {
               // prefix the entry path with the pathInContainer value.
               String entryPath = ve.getPath();
-              
-              if(entryPath==null || entryPath.isEmpty()) {
+
+              if (entryPath == null || entryPath.isEmpty()) {
                 throw new IOException("Error path was empty");
               }
-              
+
               if (entryPath.startsWith("/"))
                 entryPath = entryPath.substring(1);
 
               // important! adds the parent dirs for the entries with the correct uid/gid.
               // (otherwise various buildpack tasks won't be able to write to them!)
               addParents(tout, seenDirs, uid, gid, entryPath);
-              
-              log.debug("adding "+entryPath+" to tar");
+
+              log.debug("adding " + entryPath + " to tar");
               // add this file entry.
               TarArchiveEntry tae = new TarArchiveEntry(entryPath);
               tae.setSize(ve.getSize());
               tae.setUserId(uid);
-              tae.setGroupId(gid);                            
-              tae.setMode(0100000 + ve.getMode()); //0100000 means 'regular file'
+              tae.setGroupId(gid);
+              tae.setMode(0100000 + ve.getMode()); // 0100000 means 'regular file'
               tout.putArchiveEntry(tae);
               tout.flush();
               DataSupplier cs = ve.getDataSupplier();
-              if(cs==null) {
+              if (cs == null) {
                 throw new IOException("Error DataSupplier was not provided");
               }
               try (InputStream is = ve.getDataSupplier().getData();) {
-                if(is==null) {
+                if (is == null) {
                   throw new IOException("Error DataSupplier gave null for getData");
                 }
                 copy(is, tout);
               }
               tout.closeArchiveEntry();
               tout.flush();
-              log.trace("add of "+entryPath+" complete");
-            } 
+              log.trace("add of " + entryPath + " complete");
+            }
           } catch (Exception e) {
             log.debug("Error during writer thread", e);
             writerException.set(e);
           }
-          log.trace("Writer thread complete");          
-        } 
-        };
+          log.trace("Writer thread complete");
+        }
+      };
 
       AtomicReference<Exception> readerException = new AtomicReference<>();
       Runnable reader = new Runnable() {
         @Override
         public void run() {
-          try{
+          try {
             log.trace("Creating copy command");
             CopyArchiveToContainerCmd c = dc.copyArchiveToContainerCmd(containerId)
-                                            .withRemotePath(containerPath)
-                                            .withTarInputStream(in);
+                .withRemotePath(containerPath)
+                .withTarInputStream(in);
             log.trace("Starting copy command");
             c.exec();
             log.trace("copy command complete");
           } catch (Exception e) {
             log.trace("Error during consumer thread", e);
-            writerException.set(e);
+            readerException.set(e);
           }
           log.trace("Consumer thread complete");
         }
       };
 
-      Thread t1 = new Thread(writer,"buildpack-tar-writer-thread");
+      Thread t1 = new Thread(writer, "buildpack-tar-writer-thread");
       Thread t2 = new Thread(reader, "buildpack-tar-reader-thread");
 
-      log.debug("Copying archive to container at "+containerPath);
+      log.debug("Copying archive to container at " + containerPath);
 
       log.trace("Launching tar stream creator thread");
       t1.start();
-      //add delay to wait for writer a bit.. 
-      try{
+      // add delay to wait for writer a bit..
+      try {
         Thread.sleep(500);
-      }catch(InterruptedException ie){
-        //ignore
+      } catch (InterruptedException ie) {
+        // ignore
       }
       log.trace("Launching tar stream consumer thread");
       t2.start();
 
       log.trace("joining threads");
-      try {        
+      try {
         t1.join();
         log.trace("-writer joined");
         t2.join();
@@ -318,33 +322,34 @@ public class ContainerUtils {
       }
       log.trace("copy contents complete without error.");
     } catch (IOException e) {
-        log.debug("IOException during copy content to container",e);
-        throw BuildpackException.launderThrowable(e);
+      log.debug("IOException during copy content to container", e);
+      throw BuildpackException.launderThrowable(e);
     }
   }
 
   public static byte[] getFileFromContainer(DockerClient dc, String id, String path) {
-    CopyArchiveFromContainerCmd copycmd = dc.copyArchiveFromContainerCmd(id, path);    
+    CopyArchiveFromContainerCmd copycmd = dc.copyArchiveFromContainerCmd(id, path);
     ByteArrayOutputStream file = new ByteArrayOutputStream();
-    try{
+    try {
       InputStream tarStream = copycmd.exec();
       TarArchiveInputStream tarInput = new TarArchiveInputStream(tarStream);
-      try{
+      try {
         TarArchiveEntry tarEntry = tarInput.getNextTarEntry();
-        while(tarEntry!=null){
-            copy(tarInput, file);
-            file.close();           
-            tarEntry = tarInput.getNextTarEntry();
+        while (tarEntry != null) {
+          copy(tarInput, file);
+          file.close();
+          tarEntry = tarInput.getNextTarEntry();
         }
         return file.toByteArray();
-      }finally{
-        if(tarInput!=null)tarInput.close();
+      } finally {
+        if (tarInput != null)
+          tarInput.close();
       }
-    }catch(NotFoundException nfe){
-        throw BuildpackException.launderThrowable("Unable to locate container '"+id+"'", nfe);
+    } catch (NotFoundException nfe) {
+      throw BuildpackException.launderThrowable("Unable to locate container '" + id + "'", nfe);
     } catch (IOException e) {
-        throw BuildpackException.launderThrowable("Unable to retrieve '"+path+"' from container", e);
-    }    
+      throw BuildpackException.launderThrowable("Unable to retrieve '" + path + "' from container", e);
+    }
   }
 
   private static final void copy(InputStream in, OutputStream out) {

--- a/client/src/main/java/dev/snowdrop/buildpack/docker/DockerClientUtils.java
+++ b/client/src/main/java/dev/snowdrop/buildpack/docker/DockerClientUtils.java
@@ -14,7 +14,7 @@ import org.slf4j.LoggerFactory;
 
 import dev.snowdrop.buildpack.config.RegistryAuthConfig;
 import dev.snowdrop.buildpack.config.HostAndSocketConfig;
-import dev.snowdrop.buildpack.utils.OperatingSytem;
+import dev.snowdrop.buildpack.utils.OperatingSystem;
 
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.core.DefaultDockerClientConfig;
@@ -26,17 +26,21 @@ import com.github.dockerjava.transport.DockerHttpClient;
 public class DockerClientUtils {
   private static final Logger log = LoggerFactory.getLogger(DockerClientUtils.class);
 
-  private final static String[] MAC_PODMAN_HOST = {"podman","machine","inspect","--format" ,"unix://{{.ConnectionInfo.PodmanSocket.Path}}"};
-  private final static String[] LIN_PODMAN_HOST = {"podman", "info", "--format", "unix://{{.Host.RemoteSocket.Path}}"};
-  private final static String[] WIN_PODMAN_HOST = {"podman","machine","inspect","--format" ,"npipe://{{.ConnectionInfo.PodmanPipe.Path}}"};
-  private final static String[] PODMAN_SOCKET = {"podman", "info", "--format", "{{.Host.RemoteSocket.Path}}"};
+  private final static String[] MAC_PODMAN_HOST = { "podman", "machine", "inspect", "--format",
+      "unix://{{.ConnectionInfo.PodmanSocket.Path}}" };
+  private final static String[] LIN_PODMAN_HOST = { "podman", "info", "--format",
+      "unix://{{.Host.RemoteSocket.Path}}" };
+  private final static String[] WIN_PODMAN_HOST = { "podman", "machine", "inspect", "--format",
+      "npipe://{{.ConnectionInfo.PodmanPipe.Path}}" };
+  private final static String[] PODMAN_SOCKET = { "podman", "info", "--format", "{{.Host.RemoteSocket.Path}}" };
 
   public static DockerClient getDockerClient() {
     return getDockerClient(probeContainerRuntime(null));
   }
 
   public static DockerClient getDockerClient(HostAndSocketConfig runtimeInfo) {
-    return getDockerClient(runtimeInfo, new ArrayList<RegistryAuthConfig>(){});
+    return getDockerClient(runtimeInfo, new ArrayList<RegistryAuthConfig>() {
+    });
   }
 
   /**
@@ -44,7 +48,7 @@ public class DockerClientUtils {
    * for other platforms, and we may want a way to configure authentication etc.
    */
   public static DockerClient getDockerClient(HostAndSocketConfig runtimeInfo, List<RegistryAuthConfig> authConfigs) {
-    if(runtimeInfo == null || !runtimeInfo.getHost().isPresent() || !runtimeInfo.getSocket().isPresent()) {
+    if (runtimeInfo == null || !runtimeInfo.getHost().isPresent() || !runtimeInfo.getSocket().isPresent()) {
       log.warn("Supplied host/socket was null, attempting to use auto-configured defaults");
       return getDockerClient(probeContainerRuntime(runtimeInfo), authConfigs);
     }
@@ -68,106 +72,124 @@ public class DockerClientUtils {
   }
 
   public static HostAndSocketConfig probeContainerRuntime(HostAndSocketConfig overrides) {
-    log.debug("Probing for container runtime... "+(overrides!=null ? "H:"+overrides.getHost()+" S:"+overrides.getSocket() : "no overrides"));
-    if(overrides!=null){
-      //if user has supplied both host & socket, we don't need to probe at all, use their values.
-      //(using isEmpty as isBlank is jdk11 onwards)
-      if(overrides.getHost().isPresent() && overrides.getSocket().isPresent()){
-        return new HostAndSocketConfig(overrides.getHost().get(),overrides.getSocket().get());  
+    log.debug("Probing for container runtime... "
+        + (overrides != null ? "H:" + overrides.getHost() + " S:" + overrides.getSocket() : "no overrides"));
+    if (overrides != null) {
+      // if user has supplied both host & socket, we don't need to probe at all, use
+      // their values.
+      // (using isEmpty as isBlank is jdk11 onwards)
+      if (overrides.getHost().isPresent() && overrides.getSocket().isPresent()) {
+        return new HostAndSocketConfig(overrides.getHost().get(), overrides.getSocket().get());
       }
     }
 
-    try{
-      //configure the override values as Optionals.
-      Optional<String> dockerHost = overrides==null ? Optional.empty() : overrides.getHost();
-      //for dockerhost, if user override was null, try to honor the env var
-      if(!dockerHost.isPresent()){
+    try {
+      // configure the override values as Optionals.
+      Optional<String> dockerHost = overrides == null ? Optional.empty() : overrides.getHost();
+      // for dockerhost, if user override was null, try to honor the env var
+      if (!dockerHost.isPresent()) {
         dockerHost = Optional.ofNullable(System.getenv("DOCKER_HOST"));
       }
-      Optional<String> dockerSocket = overrides==null ? Optional.empty() : overrides.getSocket();
+      Optional<String> dockerSocket = overrides == null ? Optional.empty() : overrides.getSocket();
 
-      //if we now have a host & socket, we are done.
-      if(dockerHost.isPresent() && dockerSocket.isPresent()){
-        log.debug("Using docker host "+dockerHost.get()+" and socket "+dockerSocket.get());
-        return new HostAndSocketConfig(dockerHost.get(),dockerSocket.get());
+      // if we now have a host & socket, we are done.
+      if (dockerHost.isPresent() && dockerSocket.isPresent()) {
+        log.debug("Using docker host " + dockerHost.get() + " and socket " + dockerSocket.get());
+        return new HostAndSocketConfig(dockerHost.get(), dockerSocket.get());
       }
 
-      //if dockerhost is specified, but docker socket is not, test if dockerhost is podman rootful,
-      //and autoconfigure dockersocket.. otherwise invoking podman as the user may result in the 
-      //user socket being selected for use with the rootful host, leading to failure.
-      if ( dockerHost.isPresent() && !dockerSocket.isPresent() && 
-         ( "unix:///var/run/podman/podman.sock".equals(dockerHost.get()) || "unix:///run/podman/podman.sock".equals(dockerHost.get()) )){
-        log.debug("Using podman rootful host "+dockerHost.get()+" and socket "+dockerHost.get().substring("unix://".length()));
+      // if dockerhost is specified, but docker socket is not, test if dockerhost is
+      // podman rootful,
+      // and autoconfigure dockersocket.. otherwise invoking podman as the user may
+      // result in the
+      // user socket being selected for use with the rootful host, leading to failure.
+      if (dockerHost.isPresent() && !dockerSocket.isPresent() &&
+          ("unix:///var/run/podman/podman.sock".equals(dockerHost.get())
+              || "unix:///run/podman/podman.sock".equals(dockerHost.get()))) {
+        log.debug("Using podman rootful host " + dockerHost.get() + " and socket "
+            + dockerHost.get().substring("unix://".length()));
         return new HostAndSocketConfig(dockerHost.get(), dockerHost.get().substring("unix://".length()));
       }
 
-      //we are still missing a host or socket, so we need to probe for them.
-      //try to obtain podman socket path.. 
+      // we are still missing a host or socket, so we need to probe for them.
+      // try to obtain podman socket path..
       log.info("Testing for podman/docker...");
       DockerClientUtils.CmdResult cr = DockerClientUtils.start(PODMAN_SOCKET);
-      if(cr.rc==0){
+      if (cr.rc == 0) {
         log.info("Podman detected, configuring.");
         String socket = cr.output.get(0);
-        if(socket.startsWith("unix://")){
+        if (socket.startsWith("unix://")) {
           socket = socket.substring("unix://".length());
         }
-        log.debug("Using derived socket path value of "+socket+" from podman cli invocation.");
-        //podman was present, use podman to retrieve dockerhost value
-        switch (OperatingSytem.getOperationSystem()) {
-          case WIN:{
+        log.debug("Using derived socket path value of " + socket + " from podman cli invocation.");
+        // podman was present, use podman to retrieve dockerhost value
+        switch (OperatingSystem.getOperatingSystem()) {
+          case WIN: {
             DockerClientUtils.CmdResult scmd = DockerClientUtils.start(WIN_PODMAN_HOST);
-            if(scmd.rc==0){
+            if (scmd.rc == 0) {
               String fixedhost = scmd.output.get(0).replaceAll("\\\\", "/");
               return new HostAndSocketConfig(dockerHost.orElse(fixedhost), dockerSocket.orElse(socket));
-            }else{
+            } else {
               log.warn("Unable to obtain podman socket path from podman, using internal default");
-              return new HostAndSocketConfig(dockerHost.orElse("npipe:////./pipe/docker_engine"),dockerSocket.orElse("/var/run/docker.sock"));
+              return new HostAndSocketConfig(dockerHost.orElse("npipe:////./pipe/docker_engine"),
+                  dockerSocket.orElse("/var/run/docker.sock"));
             }
           }
-          case LINUX:{
+          case LINUX: {
             DockerClientUtils.CmdResult scmd = DockerClientUtils.start(LIN_PODMAN_HOST);
-            if(scmd.rc==0){
+            if (scmd.rc == 0) {
               return new HostAndSocketConfig(dockerHost.orElse(scmd.output.get(0)), dockerSocket.orElse(socket));
-            }else{
+            } else {
               log.warn("Unable to obtain podman socket path from podman, using internal default");
-              return new HostAndSocketConfig(dockerHost.orElse("unix:///var/run/podman.sock"), dockerSocket.orElse("/var/run/podman.sock"));
+              return new HostAndSocketConfig(dockerHost.orElse("unix:///var/run/podman.sock"),
+                  dockerSocket.orElse("/var/run/podman.sock"));
             }
           }
-          case MAC:{
+          case MAC: {
             DockerClientUtils.CmdResult scmd = DockerClientUtils.start(MAC_PODMAN_HOST);
-            if(scmd.rc==0){
+            if (scmd.rc == 0) {
               return new HostAndSocketConfig(dockerHost.orElse(scmd.output.get(0)), dockerSocket.orElse(socket));
-            }else{
+            } else {
               log.warn("Unable to obtain podman socket path from podman, using internal default");
-              return new HostAndSocketConfig(dockerHost.orElse("unix:///var/run/podman.sock"), dockerSocket.orElse("/var/run/podman.sock"));
+              return new HostAndSocketConfig(dockerHost.orElse("unix:///var/run/podman.sock"),
+                  dockerSocket.orElse("/var/run/podman.sock"));
             }
           }
-          case UNKNOWN:{
-            log.warn("Unable to identify Operating System, you may need to specify docker host / docker socket manually");
-            return new HostAndSocketConfig(dockerHost.orElse("unix:///var/run/podman.sock"), dockerSocket.orElse("/var/run/podman.sock"));
+          case UNKNOWN: {
+            log.warn(
+                "Unable to identify Operating System, you may need to specify docker host / docker socket manually");
+            return new HostAndSocketConfig(dockerHost.orElse("unix:///var/run/podman.sock"),
+                dockerSocket.orElse("/var/run/podman.sock"));
           }
         }
-      }else{
+      } else {
         log.info("Assuming docker, configuring.");
-        //failed to obtain podman socket path, assuming docker.. 
-        switch (OperatingSytem.getOperationSystem()) {
-          case WIN:{
-            return new HostAndSocketConfig(dockerHost.orElse("npipe:////./pipe/docker_engine"),dockerSocket.orElse("/var/run/docker.sock"));
+        // failed to obtain podman socket path, assuming docker..
+        switch (OperatingSystem.getOperatingSystem()) {
+          case WIN: {
+            return new HostAndSocketConfig(dockerHost.orElse("npipe:////./pipe/docker_engine"),
+                dockerSocket.orElse("/var/run/docker.sock"));
           }
-          case LINUX:{
-            return new HostAndSocketConfig(dockerHost.orElse("unix:///var/run/docker.sock"), dockerSocket.orElse("/var/run/docker.sock"));
+          case LINUX: {
+            return new HostAndSocketConfig(dockerHost.orElse("unix:///var/run/docker.sock"),
+                dockerSocket.orElse("/var/run/docker.sock"));
           }
-          case MAC:{
-            return new HostAndSocketConfig(dockerHost.orElse("unix:///var/run/docker.sock"), dockerSocket.orElse("/var/run/docker.sock"));
+          case MAC: {
+            return new HostAndSocketConfig(dockerHost.orElse("unix:///var/run/docker.sock"),
+                dockerSocket.orElse("/var/run/docker.sock"));
           }
-          case UNKNOWN:{
-            log.warn("Unable to identify Operating System, you may need to specify docker host / docker socket manually");
-            return new HostAndSocketConfig(dockerHost.orElse("unix:///var/run/docker.sock"), dockerSocket.orElse("/var/run/docker.sock"));
+          case UNKNOWN: {
+            log.warn(
+                "Unable to identify Operating System, you may need to specify docker host / docker socket manually");
+            return new HostAndSocketConfig(dockerHost.orElse("unix:///var/run/docker.sock"),
+                dockerSocket.orElse("/var/run/docker.sock"));
           }
         }
       }
-    }catch(Exception e){
-      log.error("Error during Container Runtime Probe, verify podman/docker, or set Docker Host and Docker Socket explicitly", e);
+    } catch (Exception e) {
+      log.error(
+          "Error during Container Runtime Probe, verify podman/docker, or set Docker Host and Docker Socket explicitly",
+          e);
     }
     log.error("Failed to determine docker host and docker socket path.");
     throw new IllegalStateException("Container Runtime detection failure");
@@ -176,36 +198,39 @@ public class DockerClientUtils {
   private static class CmdResult {
     public final int rc;
     public final List<String> output;
-    public CmdResult(int rc, List<String> out){ this.rc=rc; this.output = out;}
+
+    public CmdResult(int rc, List<String> out) {
+      this.rc = rc;
+      this.output = out;
+    }
   }
 
-  private static CmdResult start(String[] cmd)
-  {
-      try{
-        log.debug("Process start "+Arrays.toString(cmd));
+  private static CmdResult start(String[] cmd) {
+    try {
+      log.debug("Process start " + Arrays.toString(cmd));
 
-        // Launch and wait:
-        ProcessBuilder pb = new ProcessBuilder(cmd);
-        pb.redirectErrorStream(true);//merge to stderr->stdout
-        Process p = pb.start();
+      // Launch and wait:
+      ProcessBuilder pb = new ProcessBuilder(cmd);
+      pb.redirectErrorStream(true);// merge to stderr->stdout
+      Process p = pb.start();
 
-        List<String> output = null;
-        try(InputStream stdo = p.getInputStream()) {
-            BufferedReader lineReader = new BufferedReader(new InputStreamReader(stdo));
-            output = lineReader.lines().collect(Collectors.toList());
-        }
-
-        int rc = p.waitFor();
-
-        log.debug("Process exit rc:"+rc +" response:"+output);
-        return new CmdResult(rc,output);
-      }catch(Exception e){
-        List<String> failReason = new ArrayList<>();
-        failReason.add("Process failed: ... ");
-        for (StackTraceElement ste : e.getStackTrace()) {
-          failReason.add(ste.toString());
-        }
-        return new CmdResult(255, failReason);
+      List<String> output = null;
+      try (InputStream stdo = p.getInputStream()) {
+        BufferedReader lineReader = new BufferedReader(new InputStreamReader(stdo));
+        output = lineReader.lines().collect(Collectors.toList());
       }
-  }  
+
+      int rc = p.waitFor();
+
+      log.debug("Process exit rc:" + rc + " response:" + output);
+      return new CmdResult(rc, output);
+    } catch (Exception e) {
+      List<String> failReason = new ArrayList<>();
+      failReason.add("Process failed: ... ");
+      for (StackTraceElement ste : e.getStackTrace()) {
+        failReason.add(ste.toString());
+      }
+      return new CmdResult(255, failReason);
+    }
+  }
 }

--- a/client/src/main/java/dev/snowdrop/buildpack/docker/ImageUtils.java
+++ b/client/src/main/java/dev/snowdrop/buildpack/docker/ImageUtils.java
@@ -156,8 +156,12 @@ public class ImageUtils {
       }
     }
 
-    if(lastSeen!=null && !allDone){
-      throw lastSeen;
+    if (!allDone) {
+      if (lastSeen != null) {
+        throw lastSeen;
+      } else {
+        throw new BuildpackException("Image pull operations timed out", new java.util.concurrent.TimeoutException());
+      }
     }
   }
 

--- a/client/src/main/java/dev/snowdrop/buildpack/lifecycle/LifecycleExecutor.java
+++ b/client/src/main/java/dev/snowdrop/buildpack/lifecycle/LifecycleExecutor.java
@@ -177,7 +177,7 @@ public class LifecycleExecutor {
         ImageReference runRef = getRunReference(phase);
         if(runRef!=null){
             String oldToml = new String(phase.getAnalyzedToml());
-            String newToml = oldToml.replaceAll(runRef.getReference(),runRef.getReferenceWithLatest());     
+            String newToml = oldToml.replace(runRef.getReference(),runRef.getReferenceWithLatest());     
             phase.updateAnalyzedToml(newToml);
             return runRef;
         }else{

--- a/client/src/main/java/dev/snowdrop/buildpack/lifecycle/Version.java
+++ b/client/src/main/java/dev/snowdrop/buildpack/lifecycle/Version.java
@@ -27,6 +27,23 @@ public class Version {
         return version;
     }
 
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        Version other = (Version) obj;
+        return this.major == other.major && this.minor == other.minor;
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * major + minor;
+    }
+
     public boolean equals(Version v){
         return this.major == v.major && this.minor == v.minor;
     }

--- a/client/src/main/java/dev/snowdrop/buildpack/lifecycle/phases/Restorer.java
+++ b/client/src/main/java/dev/snowdrop/buildpack/lifecycle/phases/Restorer.java
@@ -61,6 +61,10 @@ public class Restorer implements LifecyclePhase, LifecyclePhaseAnalyzedTomlUpdat
             runAsId = 0;
         }
 
+        if(factory.getPlatformLevel().atLeast("0.14")){
+            args.addArg("-run", "/cnb/run.toml");
+        }
+
 
         String id = factory.getContainerForPhase(args.toArray(), runAsId);
         try{

--- a/client/src/main/java/dev/snowdrop/buildpack/utils/JsonUtils.java
+++ b/client/src/main/java/dev/snowdrop/buildpack/utils/JsonUtils.java
@@ -8,6 +8,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 public class JsonUtils {
     public static String getValue(JsonNode root, String path) {
+        if (path.startsWith("/")) {
+            path = path.substring(1);
+        }
         String[] parts = path.split("/");
         JsonNode next = root.get(parts[0]);
         if (next != null && parts.length > 1) {
@@ -19,6 +22,9 @@ public class JsonUtils {
         return next.asText();
       }
    public static List<String> getArray(JsonNode root, String path) {
+        if (path.startsWith("/")) {
+            path = path.substring(1);
+        }
         String[] parts = path.split("/");
         JsonNode next = root.get(parts[0]);
         if (next != null && parts.length > 1) {

--- a/client/src/main/java/dev/snowdrop/buildpack/utils/OperatingSystem.java
+++ b/client/src/main/java/dev/snowdrop/buildpack/utils/OperatingSystem.java
@@ -1,15 +1,15 @@
 package dev.snowdrop.buildpack.utils;
 
-public enum OperatingSytem {
+public enum OperatingSystem {
 
   WIN,
   LINUX,
   MAC,
   UNKNOWN;
-  
-  private static OperatingSytem os;
 
-  public static OperatingSytem getOperationSystem() {
+  private static OperatingSystem os;
+
+  public static OperatingSystem getOperatingSystem() {
     if (os == null) {
       String osName = System.getProperty("os.name").toLowerCase();
       if (osName.contains("win")) {
@@ -18,7 +18,7 @@ public enum OperatingSytem {
         os = LINUX;
       } else if (osName.contains("mac")) {
         os = MAC;
-      } else  { 
+      } else {
         os = UNKNOWN;
       }
     }

--- a/client/src/test/java/dev/snowdrop/buildpack/ContainerLogReaderTest.java
+++ b/client/src/test/java/dev/snowdrop/buildpack/ContainerLogReaderTest.java
@@ -1,0 +1,57 @@
+package dev.snowdrop.buildpack;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.github.dockerjava.api.model.Frame;
+import com.github.dockerjava.api.model.StreamType;
+
+@ExtendWith(MockitoExtension.class)
+public class ContainerLogReaderTest {
+
+  @Mock
+  private Logger logger;
+
+  @Test
+  void testStdoutFrame() {
+    ContainerLogReader reader = new ContainerLogReader(logger);
+    byte[] payload = "Hello Stdout".getBytes(StandardCharsets.UTF_8);
+    Frame frame = new Frame(StreamType.STDOUT, payload);
+
+    reader.onNext(frame);
+
+    verify(logger).stdout("Hello Stdout");
+    verifyNoMoreInteractions(logger); // stdout is the only method called
+  }
+
+  @Test
+  void testStderrFrame() {
+    ContainerLogReader reader = new ContainerLogReader(logger);
+    byte[] payload = "Hello Stderr".getBytes(StandardCharsets.UTF_8);
+    Frame frame = new Frame(StreamType.STDERR, payload);
+
+    reader.onNext(frame);
+
+    verify(logger).stderr("Hello Stderr");
+    verifyNoMoreInteractions(logger); // stderr is the only method called
+  }
+
+  @Test
+  void testRawFrameIgnored() {
+    ContainerLogReader reader = new ContainerLogReader(logger);
+    byte[] payload = "Raw bytes".getBytes(StandardCharsets.UTF_8);
+    Frame frame = new Frame(StreamType.RAW, payload);
+
+    reader.onNext(frame);
+
+    verifyNoInteractions(logger);
+  }
+}

--- a/client/src/test/java/dev/snowdrop/buildpack/LoggerTest.java
+++ b/client/src/test/java/dev/snowdrop/buildpack/LoggerTest.java
@@ -1,0 +1,57 @@
+package dev.snowdrop.buildpack;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class LoggerTest {
+
+  private static class TestLogger implements Logger {
+    private final boolean ansiEnabled;
+
+    TestLogger(boolean ansiEnabled) {
+      this.ansiEnabled = ansiEnabled;
+    }
+
+    @Override
+    public void stdout(String message) {}
+
+    @Override
+    public void stderr(String message) {}
+
+    @Override
+    public boolean isAnsiColorEnabled() {
+      return ansiEnabled;
+    }
+  }
+
+  @Test
+  void testPrepareEndsWithNewline() {
+    Logger logger = new TestLogger(true);
+    assertEquals("hello", logger.prepare("hello\n"));
+    assertEquals("hello", logger.prepare("hello"));
+    assertEquals("", logger.prepare("\n"));
+  }
+
+  @Test
+  void testPrepareAnsiStripping() {
+    Logger noAnsi = new TestLogger(false);
+    // The current regex in Logger.java is: " [^m]+m"
+    assertEquals("hello", noAnsi.prepare("hello\u001b[31m"));
+    
+    Logger ansi = new TestLogger(true);
+    assertEquals("hello\u001b[31m", ansi.prepare("hello\u001b[31m"));
+  }
+
+  @Test
+  void testDefaultIsAnsiColorEnabled() {
+    Logger defaultLogger = new Logger() {
+      @Override public void stdout(String message) {}
+      @Override public void stderr(String message) {}
+    };
+    assertFalse(defaultLogger.isAnsiColorEnabled());
+  }
+
+}

--- a/client/src/test/java/dev/snowdrop/buildpack/config/HostAndSocketConfigTest.java
+++ b/client/src/test/java/dev/snowdrop/buildpack/config/HostAndSocketConfigTest.java
@@ -1,0 +1,34 @@
+package dev.snowdrop.buildpack.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class HostAndSocketConfigTest {
+
+    @Test
+    void testHostAndSocketConfigBuilderAndGetters() {
+        HostAndSocketConfig config = HostAndSocketConfig.builder()
+            .withHost("localhost")
+            .withSocket("/var/run/docker.sock")
+            .build();
+
+        assertNotNull(config);
+        assertTrue(config.getHost().isPresent());
+        assertEquals("localhost", config.getHost().get());
+        assertTrue(config.getSocket().isPresent());
+        assertEquals("/var/run/docker.sock", config.getSocket().get());
+    }
+
+    @Test
+    void testHostAndSocketConfigEmpty() {
+        HostAndSocketConfig config = HostAndSocketConfig.builder().build();
+
+        assertNotNull(config);
+        assertFalse(config.getHost().isPresent());
+        assertFalse(config.getSocket().isPresent());
+    }
+}

--- a/client/src/test/java/dev/snowdrop/buildpack/config/RegistryAuthConfigTest.java
+++ b/client/src/test/java/dev/snowdrop/buildpack/config/RegistryAuthConfigTest.java
@@ -1,0 +1,31 @@
+package dev.snowdrop.buildpack.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+public class RegistryAuthConfigTest {
+
+    @Test
+    void testRegistryAuthConfigBuilderAndGetters() {
+        RegistryAuthConfig config = RegistryAuthConfig.builder()
+            .withRegistryAddress("https://registry.example.com")
+            .withRegistryToken("token-xyz")
+            .withUsername("test-user")
+            .withAuth("auth-token")
+            .withEmail("user@example.com")
+            .withIdentityToken("identity-token-123")
+            .withPassword("secret-pass")
+            .build();
+
+        assertNotNull(config);
+        assertEquals("https://registry.example.com", config.getRegistryAddress());
+        assertEquals("token-xyz", config.getRegistryToken());
+        assertEquals("test-user", config.getUsername());
+        assertEquals("auth-token", config.getAuth());
+        assertEquals("user@example.com", config.getEmail());
+        assertEquals("identity-token-123", config.getIdentityToken());
+        assertEquals("secret-pass", config.getPassword());
+    }
+}

--- a/client/src/test/java/dev/snowdrop/buildpack/docker/ImageUtilsTest.java
+++ b/client/src/test/java/dev/snowdrop/buildpack/docker/ImageUtilsTest.java
@@ -25,6 +25,7 @@ import com.github.dockerjava.api.command.InspectImageCmd;
 import com.github.dockerjava.api.command.InspectImageResponse;
 import com.github.dockerjava.api.command.ListImagesCmd;
 import com.github.dockerjava.api.command.PullImageCmd;
+import com.github.dockerjava.api.command.PullImageResultCallback;
 import com.github.dockerjava.api.model.ContainerConfig;
 import com.github.dockerjava.api.model.Image;
 
@@ -76,10 +77,18 @@ public class ImageUtilsTest {
     
     lenient().when(config.getDockerClient()).thenReturn(dc);
     lenient().when(config.getPullPolicy()).thenReturn(DockerConfig.PullPolicy.IF_NOT_PRESENT);
+    lenient().when(config.getPullTimeoutSeconds()).thenReturn(30);
+    lenient().when(config.getPullRetryCount()).thenReturn(0);
+    lenient().when(config.getPullRetryIncreaseSeconds()).thenReturn(0);
     lenient().when(dc.listImagesCmd()).thenReturn(lic);
     lenient().when(lic.exec()).thenReturn(new ArrayList<Image>());
     
     when(dc.pullImageCmd(eq(imageName))).thenReturn(pic);
+    when(pic.exec(ArgumentMatchers.any(PullImageResultCallback.class))).thenAnswer(invocation -> {
+      PullImageResultCallback callback = invocation.getArgument(0);
+      callback.onComplete();
+      return null;
+    });
     
     ImageUtils.pullImages(config, test);
     
@@ -124,6 +133,9 @@ public class ImageUtilsTest {
 
     lenient().when(config.getDockerClient()).thenReturn(dc);
     lenient().when(config.getPullPolicy()).thenReturn(DockerConfig.PullPolicy.IF_NOT_PRESENT);
+    lenient().when(config.getPullTimeoutSeconds()).thenReturn(30);
+    lenient().when(config.getPullRetryCount()).thenReturn(0);
+    lenient().when(config.getPullRetryIncreaseSeconds()).thenReturn(0);
     lenient().when(dc.listImagesCmd()).thenReturn(lic);
 
     List<Image> li = new ArrayList<Image>();
@@ -132,6 +144,11 @@ public class ImageUtilsTest {
     when(i.getRepoTags()).thenReturn(new String[] {imageName});
 
     when(dc.pullImageCmd(eq(imageName))).thenReturn(pic);
+    when(pic.exec(ArgumentMatchers.any(PullImageResultCallback.class))).thenAnswer(invocation -> {
+      PullImageResultCallback callback = invocation.getArgument(0);
+      callback.onComplete();
+      return null;
+    });
     
     ImageUtils.pullImages(config, test);
     
@@ -150,6 +167,9 @@ public class ImageUtilsTest {
 
     lenient().when(config.getDockerClient()).thenReturn(dc);
     lenient().when(config.getPullPolicy()).thenReturn(DockerConfig.PullPolicy.IF_NOT_PRESENT);
+    lenient().when(config.getPullTimeoutSeconds()).thenReturn(30);
+    lenient().when(config.getPullRetryCount()).thenReturn(0);
+    lenient().when(config.getPullRetryIncreaseSeconds()).thenReturn(0);
     lenient().when(dc.listImagesCmd()).thenReturn(lic);
 
     List<Image> li = new ArrayList<Image>();
@@ -158,6 +178,11 @@ public class ImageUtilsTest {
     when(i.getRepoTags()).thenReturn(new String[] {imageName});
 
     when(dc.pullImageCmd(eq(imageName))).thenReturn(pic);
+    when(pic.exec(ArgumentMatchers.any(PullImageResultCallback.class))).thenAnswer(invocation -> {
+      PullImageResultCallback callback = invocation.getArgument(0);
+      callback.onComplete();
+      return null;
+    });
     
     ImageUtils.pullImages(config, test);
     

--- a/client/src/test/java/dev/snowdrop/buildpack/lifecycle/VersionTest.java
+++ b/client/src/test/java/dev/snowdrop/buildpack/lifecycle/VersionTest.java
@@ -1,0 +1,110 @@
+package dev.snowdrop.buildpack.lifecycle;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import dev.snowdrop.buildpack.BuildpackException;
+
+public class VersionTest {
+
+  @Test
+  void testValidParsing() {
+    Version v1 = new Version("1.2");
+    assertEquals(1, v1.major);
+    assertEquals(2, v1.minor);
+    assertEquals("1.2", v1.toString());
+
+    Version v2 = new Version("0.3.5");
+    assertEquals(0, v2.major);
+    assertEquals(3, v2.minor);
+    assertEquals("0.3.5", v2.toString());
+
+    Version v3 = new Version("10.20.rc1");
+    assertEquals(10, v3.major);
+    assertEquals(20, v3.minor);
+    assertEquals("10.20.rc1", v3.toString());
+  }
+
+  @Test
+  void testInvalidParsing() {
+    assertThrows(BuildpackException.class, () -> new Version("1"));
+    assertThrows(BuildpackException.class, () -> new Version("abc"));
+    assertThrows(BuildpackException.class, () -> new Version(""));
+    assertThrows(NullPointerException.class, () -> new Version(null));
+  }
+
+  @Test
+  void testEqualsAndHashCode() {
+    Version v1 = new Version("1.2");
+    Version v2 = new Version("1.2.3");
+    Version v3 = new Version("1.3");
+
+    // Standard equals contract
+    assertEquals(v1, v1);
+    assertEquals(v1, v2);
+    assertNotEquals(v1, v3);
+    assertNotEquals(v1, null);
+    assertNotEquals(v1, "1.2"); // different type
+
+    // String convenience equals
+    assertTrue(v1.equals("1.2.3"));
+    assertFalse(v1.equals("1.3"));
+
+    // HashCode contract
+    assertEquals(v1.hashCode(), v2.hashCode());
+    assertNotEquals(v1.hashCode(), v3.hashCode());
+  }
+
+  @Test
+  void testComparisons() {
+    Version v12 = new Version("1.2");
+    Version v13 = new Version("1.3");
+    Version v22 = new Version("2.2");
+
+    // greaterThan
+    assertTrue(v13.greaterThan(v12));
+    assertTrue(v22.greaterThan(v13));
+    assertFalse(v12.greaterThan(v13));
+    assertFalse(v12.greaterThan(v12));
+
+    // greaterThan (String convenience)
+    assertTrue(v13.greaterThan("1.2"));
+    assertFalse(v12.greaterThan("1.3"));
+
+    // lessThan
+    assertTrue(v12.lessThan(v13));
+    assertTrue(v13.lessThan(v22));
+    assertFalse(v13.lessThan(v12));
+    assertFalse(v12.lessThan(v12));
+
+    // lessThan (String convenience)
+    assertTrue(v12.lessThan("1.3"));
+    assertFalse(v13.lessThan("1.2"));
+
+    // atLeast
+    assertTrue(v13.atLeast(v12));
+    assertTrue(v12.atLeast(v12));
+    assertFalse(v12.atLeast(v13));
+
+    // atLeast (String convenience)
+    assertTrue(v13.atLeast("1.2"));
+    assertTrue(v12.atLeast("1.2"));
+    assertFalse(v12.atLeast("1.3"));
+
+    // atMost
+    assertTrue(v12.atMost(v13));
+    assertTrue(v12.atMost(v12));
+    assertFalse(v13.atMost(v12));
+
+    // atMost (String convenience)
+    assertTrue(v12.atMost("1.3"));
+    assertTrue(v12.atMost("1.2"));
+    assertFalse(v13.atMost("1.2"));
+  }
+
+}

--- a/client/src/test/java/dev/snowdrop/buildpack/lifecycle/phases/AnalzyerTest.java
+++ b/client/src/test/java/dev/snowdrop/buildpack/lifecycle/phases/AnalzyerTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -39,113 +40,30 @@ import dev.snowdrop.buildpack.lifecycle.Version;
 @ExtendWith(MockitoExtension.class)
 public class AnalzyerTest {
 
+    private static final String LOG_LEVEL = "debug";
+    private static final String CONTAINER_ID = "999";
+    private static final int CONTAINER_RC = 99;
+    private static final int USER_ID = 77;
+    private static final int GROUP_ID = 88;
+    private static final String OUTPUT_IMAGE = "stiletto";
+    private static final boolean USE_DAEMON = false;
+
     @Captor
     ArgumentCaptor<String[]> argsCaptor;
 
-    @Test
-    void testPre9(@Mock LifecyclePhaseFactory factory, 
-                  @Mock BuilderImage builder, 
-                  @Mock LogConfig logConfig, 
-                  @Mock DockerConfig dockerConfig, 
-                  @Mock DockerClient dockerClient,
-                  @Mock StartContainerCmd startCmd,
-                  @Mock LogContainerCmd logCmd,
-                  @Mock WaitContainerCmd waitCmd,
-                  @Mock WaitContainerResultCallback waitResult,
-                  @Mock Logger logger
-                  ) {
-        
-        String  PLATFORM_LEVEL="0.7";
-        String  LOG_LEVEL="debug";
-        String  CONTAINER_ID="999";
-        int     CONTAINER_RC=99;
-        int     USER_ID=77;
-        int     GROUP_ID=88;
-        String  OUTPUT_IMAGE="stiletto";
-        boolean USE_DAEMON=false;
+    @Mock LifecyclePhaseFactory factory;
+    @Mock BuilderImage builder;
+    @Mock LogConfig logConfig;
+    @Mock DockerConfig dockerConfig;
+    @Mock DockerClient dockerClient;
+    @Mock StartContainerCmd startCmd;
+    @Mock LogContainerCmd logCmd;
+    @Mock WaitContainerCmd waitCmd;
+    @Mock WaitContainerResultCallback waitResult;
+    @Mock Logger logger;
 
-        lenient().when(dockerConfig.getUseDaemon()).thenReturn(USE_DAEMON);
-        lenient().when(dockerConfig.getDockerClient()).thenReturn(dockerClient);        
-        lenient().when(factory.getDockerConfig()).thenReturn(dockerConfig);
-
-        lenient().doNothing().when(startCmd).exec();
-        lenient().when(dockerClient.startContainerCmd(any())).thenReturn(startCmd);
-
-        lenient().when(logCmd.withFollowStream(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withStdOut(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withStdErr(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withTimestamps(any())).thenReturn(logCmd);
-        lenient().when(logCmd.exec(any())).thenReturn(null);
-        lenient().when(dockerClient.logContainerCmd(any())).thenReturn(logCmd);
-
-        lenient().when(waitCmd.exec(any())).thenReturn(waitResult);
-        lenient().when(waitResult.awaitStatusCode()).thenReturn(CONTAINER_RC);
-        lenient().when(dockerClient.waitContainerCmd(any())).thenReturn(waitCmd);
-
-        lenient().when(logConfig.getLogLevel()).thenReturn(LOG_LEVEL);
-        lenient().when(factory.getLogConfig()).thenReturn(logConfig);
-
-        lenient().when(builder.getUserId()).thenReturn(USER_ID);
-        lenient().when(builder.getGroupId()).thenReturn(GROUP_ID);
-        lenient().when(builder.getRunImages(any())).thenReturn(Stream.of(new ImageReference("runimage1"), new ImageReference("runimage2")).collect(Collectors.toList()).toArray(new ImageReference[]{}));
-        lenient().when(factory.getBuilderImage()).thenReturn(builder);
-
-        lenient().when(factory.getPlatformLevel()).thenReturn(new Version(PLATFORM_LEVEL));
-
-        lenient().when(factory.getContainerForPhase(argsCaptor.capture(), any())).thenReturn(CONTAINER_ID);
-
-        lenient().when(factory.getOutputImage()).thenReturn(new ImageReference(OUTPUT_IMAGE));
-
-        Analyzer a = new Analyzer(factory);
-
-        ContainerStatus cs = a.runPhase(logger, true);
-
-        assertNotNull(cs);
-        assertEquals(CONTAINER_ID, cs.getContainerId());
-        assertEquals(CONTAINER_RC, cs.getRc());
-
-        String[] args = argsCaptor.getValue();
-        assertNotNull(args);
-        //verify 1st & last elements
-        assertEquals("/cnb/lifecycle/analyzer", args[0]);
-        assertEquals(new ImageReference(OUTPUT_IMAGE).getReferenceWithLatest(), args[args.length-1]);        
-
-        List<String> argList = Arrays.asList(args);
-        //verify no launch cache for a pre7 run
-        assertFalse(argList.contains("-launch-cache"));
-        //verify no dameon
-        assertFalse(argList.contains("-daemon"));
-        //verify log as expected
-        assertTrue(argList.contains(LOG_LEVEL));
-
-        verify(logCmd).withTimestamps(true);
-        verify(dockerClient).logContainerCmd(CONTAINER_ID);
-        verify(factory).getContainerForPhase(any(String[].class), eq(USER_ID));
-    }
-
-    @Test
-    void testDisableTimestamps(@Mock LifecyclePhaseFactory factory, 
-                  @Mock BuilderImage builder, 
-                  @Mock LogConfig logConfig, 
-                  @Mock DockerConfig dockerConfig, 
-                  @Mock DockerClient dockerClient,
-                  @Mock StartContainerCmd startCmd,
-                  @Mock LogContainerCmd logCmd,
-                  @Mock WaitContainerCmd waitCmd,
-                  @Mock WaitContainerResultCallback waitResult,
-                  @Mock Logger logger
-                  ) 
-    {
-        
-        String  PLATFORM_LEVEL="0.9";
-        String  LOG_LEVEL="debug";
-        String  CONTAINER_ID="999";
-        int     CONTAINER_RC=99;
-        int     USER_ID=77;
-        int     GROUP_ID=88;
-        String  OUTPUT_IMAGE="stiletto";
-        boolean USE_DAEMON=false;
-
+    @BeforeEach
+    void setUp() {
         lenient().when(dockerConfig.getUseDaemon()).thenReturn(USE_DAEMON);
         lenient().when(dockerConfig.getDockerClient()).thenReturn(dockerClient);        
         lenient().when(factory.getDockerConfig()).thenReturn(dockerConfig);
@@ -172,11 +90,41 @@ public class AnalzyerTest {
         lenient().when(builder.getRunImages(any())).thenReturn(Stream.of(new ImageReference("runimage1"), new ImageReference("runimage2")).collect(Collectors.toList()).toArray(new ImageReference[]{}));        
         lenient().when(factory.getBuilderImage()).thenReturn(builder);
 
-        lenient().when(factory.getPlatformLevel()).thenReturn(new Version(PLATFORM_LEVEL));
-
         lenient().when(factory.getContainerForPhase(argsCaptor.capture(), any())).thenReturn(CONTAINER_ID);
 
         lenient().when(factory.getOutputImage()).thenReturn(new ImageReference(OUTPUT_IMAGE));
+    }
+
+    @Test
+    void testPre9() {
+        lenient().when(factory.getPlatformLevel()).thenReturn(new Version("0.7"));
+
+        Analyzer a = new Analyzer(factory);
+
+        ContainerStatus cs = a.runPhase(logger, true);
+
+        assertNotNull(cs);
+        assertEquals(CONTAINER_ID, cs.getContainerId());
+        assertEquals(CONTAINER_RC, cs.getRc());
+
+        String[] args = argsCaptor.getValue();
+        assertNotNull(args);
+        assertEquals("/cnb/lifecycle/analyzer", args[0]);
+        assertEquals(new ImageReference(OUTPUT_IMAGE).getReferenceWithLatest(), args[args.length-1]);        
+
+        List<String> argList = Arrays.asList(args);
+        assertFalse(argList.contains("-launch-cache"));
+        assertFalse(argList.contains("-daemon"));
+        assertTrue(argList.contains(LOG_LEVEL));
+
+        verify(logCmd).withTimestamps(true);
+        verify(dockerClient).logContainerCmd(CONTAINER_ID);
+        verify(factory).getContainerForPhase(any(String[].class), eq(USER_ID));
+    }
+
+    @Test
+    void testDisableTimestamps() {
+        lenient().when(factory.getPlatformLevel()).thenReturn(new Version("0.9"));
 
         Analyzer a = new Analyzer(factory);
 
@@ -188,17 +136,12 @@ public class AnalzyerTest {
 
         String[] args = argsCaptor.getValue();
         assertNotNull(args);
-        //verify 1st & last elements
         assertEquals("/cnb/lifecycle/analyzer", args[0]);
         assertEquals(new ImageReference(OUTPUT_IMAGE).getReferenceWithLatest(), args[args.length-1]);
 
         List<String> argList = Arrays.asList(args);
-        //verify launch cache for a 9 onwards run 
-        //launch cache only valid with daemon mode.
         assertFalse(argList.contains("-launch-cache"));
-        //verify dameon
         assertFalse(argList.contains("-daemon"));
-        //verify log as expected
         assertTrue(argList.contains(LOG_LEVEL));
 
         verify(logCmd).withTimestamps(false);
@@ -207,59 +150,8 @@ public class AnalzyerTest {
     }  
 
     @Test
-    void test9OnwardsWithoutDaemon(@Mock LifecyclePhaseFactory factory, 
-                  @Mock BuilderImage builder, 
-                  @Mock LogConfig logConfig, 
-                  @Mock DockerConfig dockerConfig, 
-                  @Mock DockerClient dockerClient,
-                  @Mock StartContainerCmd startCmd,
-                  @Mock LogContainerCmd logCmd,
-                  @Mock WaitContainerCmd waitCmd,
-                  @Mock WaitContainerResultCallback waitResult,
-                  @Mock Logger logger
-                  ) 
-    {
-        
-        String  PLATFORM_LEVEL="0.9";
-        String  LOG_LEVEL="debug";
-        String  CONTAINER_ID="999";
-        int     CONTAINER_RC=99;
-        int     USER_ID=77;
-        int     GROUP_ID=88;
-        String  OUTPUT_IMAGE="stiletto";
-        boolean USE_DAEMON=false;
-
-        lenient().when(dockerConfig.getUseDaemon()).thenReturn(USE_DAEMON);
-        lenient().when(dockerConfig.getDockerClient()).thenReturn(dockerClient);        
-        lenient().when(factory.getDockerConfig()).thenReturn(dockerConfig);
-
-        lenient().doNothing().when(startCmd).exec();
-        lenient().when(dockerClient.startContainerCmd(any())).thenReturn(startCmd);
-
-        lenient().when(logCmd.withFollowStream(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withStdOut(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withStdErr(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withTimestamps(any())).thenReturn(logCmd);
-        lenient().when(logCmd.exec(any())).thenReturn(null);
-        lenient().when(dockerClient.logContainerCmd(any())).thenReturn(logCmd);
-
-        lenient().when(waitCmd.exec(any())).thenReturn(waitResult);
-        lenient().when(waitResult.awaitStatusCode()).thenReturn(CONTAINER_RC);
-        lenient().when(dockerClient.waitContainerCmd(any())).thenReturn(waitCmd);
-
-        lenient().when(logConfig.getLogLevel()).thenReturn(LOG_LEVEL);
-        lenient().when(factory.getLogConfig()).thenReturn(logConfig);
-
-        lenient().when(builder.getUserId()).thenReturn(USER_ID);
-        lenient().when(builder.getGroupId()).thenReturn(GROUP_ID);
-        lenient().when(builder.getRunImages(any())).thenReturn(Stream.of(new ImageReference("runimage1"), new ImageReference("runimage2")).collect(Collectors.toList()).toArray(new ImageReference[]{}));        
-        lenient().when(factory.getBuilderImage()).thenReturn(builder);
-
-        lenient().when(factory.getPlatformLevel()).thenReturn(new Version(PLATFORM_LEVEL));
-
-        lenient().when(factory.getContainerForPhase(argsCaptor.capture(), any())).thenReturn(CONTAINER_ID);
-
-        lenient().when(factory.getOutputImage()).thenReturn(new ImageReference(OUTPUT_IMAGE));
+    void test9OnwardsWithoutDaemon() {
+        lenient().when(factory.getPlatformLevel()).thenReturn(new Version("0.9"));
 
         Analyzer a = new Analyzer(factory);
 
@@ -271,17 +163,12 @@ public class AnalzyerTest {
 
         String[] args = argsCaptor.getValue();
         assertNotNull(args);
-        //verify 1st & last elements
         assertEquals("/cnb/lifecycle/analyzer", args[0]);
         assertEquals(new ImageReference(OUTPUT_IMAGE).getReferenceWithLatest(), args[args.length-1]);
 
         List<String> argList = Arrays.asList(args);
-        //verify launch cache for a 9 onwards run 
-        //launch cache only valid with daemon mode.
         assertFalse(argList.contains("-launch-cache"));
-        //verify dameon
         assertFalse(argList.contains("-daemon"));
-        //verify log as expected
         assertTrue(argList.contains(LOG_LEVEL));
 
         verify(logCmd).withTimestamps(true);
@@ -290,59 +177,9 @@ public class AnalzyerTest {
     }     
 
     @Test
-    void test9OnwardsWithDaemon(@Mock LifecyclePhaseFactory factory, 
-                  @Mock BuilderImage builder, 
-                  @Mock LogConfig logConfig, 
-                  @Mock DockerConfig dockerConfig, 
-                  @Mock DockerClient dockerClient,
-                  @Mock StartContainerCmd startCmd,
-                  @Mock LogContainerCmd logCmd,
-                  @Mock WaitContainerCmd waitCmd,
-                  @Mock WaitContainerResultCallback waitResult,
-                  @Mock Logger logger
-                  ) 
-    {
-        
-        String  PLATFORM_LEVEL="0.9";
-        String  LOG_LEVEL="debug";
-        String  CONTAINER_ID="999";
-        int     CONTAINER_RC=99;
-        int     USER_ID=77;
-        int     GROUP_ID=88;
-        String  OUTPUT_IMAGE="stiletto";
-        boolean USE_DAEMON=true;
-
-        lenient().when(dockerConfig.getUseDaemon()).thenReturn(USE_DAEMON);
-        lenient().when(dockerConfig.getDockerClient()).thenReturn(dockerClient);        
-        lenient().when(factory.getDockerConfig()).thenReturn(dockerConfig);
-
-        lenient().doNothing().when(startCmd).exec();
-        lenient().when(dockerClient.startContainerCmd(any())).thenReturn(startCmd);
-
-        lenient().when(logCmd.withFollowStream(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withStdOut(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withStdErr(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withTimestamps(any())).thenReturn(logCmd);
-        lenient().when(logCmd.exec(any())).thenReturn(null);
-        lenient().when(dockerClient.logContainerCmd(any())).thenReturn(logCmd);
-
-        lenient().when(waitCmd.exec(any())).thenReturn(waitResult);
-        lenient().when(waitResult.awaitStatusCode()).thenReturn(CONTAINER_RC);
-        lenient().when(dockerClient.waitContainerCmd(any())).thenReturn(waitCmd);
-
-        lenient().when(logConfig.getLogLevel()).thenReturn(LOG_LEVEL);
-        lenient().when(factory.getLogConfig()).thenReturn(logConfig);
-
-        lenient().when(builder.getUserId()).thenReturn(USER_ID);
-        lenient().when(builder.getGroupId()).thenReturn(GROUP_ID);
-        lenient().when(builder.getRunImages(any())).thenReturn(Stream.of(new ImageReference("runimage1"), new ImageReference("runimage2")).collect(Collectors.toList()).toArray(new ImageReference[]{}));       
-        lenient().when(factory.getBuilderImage()).thenReturn(builder);
-
-        lenient().when(factory.getPlatformLevel()).thenReturn(new Version(PLATFORM_LEVEL));
-
-        lenient().when(factory.getContainerForPhase(argsCaptor.capture(), any())).thenReturn(CONTAINER_ID);
-
-        lenient().when(factory.getOutputImage()).thenReturn(new ImageReference(OUTPUT_IMAGE));
+    void test9OnwardsWithDaemon() {
+        lenient().when(dockerConfig.getUseDaemon()).thenReturn(true);
+        lenient().when(factory.getPlatformLevel()).thenReturn(new Version("0.9"));
 
         Analyzer a = new Analyzer(factory);
 
@@ -354,20 +191,16 @@ public class AnalzyerTest {
 
         String[] args = argsCaptor.getValue();
         assertNotNull(args);
-        //verify 1st & last elements
         assertEquals("/cnb/lifecycle/analyzer", args[0]);
         assertEquals(new ImageReference(OUTPUT_IMAGE).getReferenceWithLatest(), args[args.length-1]);
 
         List<String> argList = Arrays.asList(args);
-        //verify launch cache for a 9 onwards run
         assertTrue(argList.contains("-launch-cache"));
-        //verify dameon
         assertTrue(argList.contains("-daemon"));
-        //verify log as expected
         assertTrue(argList.contains(LOG_LEVEL));
 
         verify(logCmd).withTimestamps(true);
         verify(dockerClient).logContainerCmd(CONTAINER_ID);
-        verify(factory).getContainerForPhase(any(String[].class), eq(0)); //running as root with daemon
+        verify(factory).getContainerForPhase(any(String[].class), eq(0));
     }    
 }

--- a/client/src/test/java/dev/snowdrop/buildpack/lifecycle/phases/BuilderTest.java
+++ b/client/src/test/java/dev/snowdrop/buildpack/lifecycle/phases/BuilderTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -39,31 +40,30 @@ import dev.snowdrop.buildpack.lifecycle.Version;
 @ExtendWith(MockitoExtension.class)
 public class BuilderTest {
 
+    private static final String LOG_LEVEL = "debug";
+    private static final String CONTAINER_ID = "999";
+    private static final int CONTAINER_RC = 99;
+    private static final int USER_ID = 77;
+    private static final int GROUP_ID = 88;
+    private static final String OUTPUT_IMAGE = "stiletto";
+    private static final boolean USE_DAEMON = false;
+
     @Captor
     ArgumentCaptor<String[]> argsCaptor;
 
-    @Test
-    void testBuilder(@Mock LifecyclePhaseFactory factory, 
-                  @Mock BuilderImage builder, 
-                  @Mock LogConfig logConfig, 
-                  @Mock DockerConfig dockerConfig, 
-                  @Mock DockerClient dockerClient,
-                  @Mock StartContainerCmd startCmd,
-                  @Mock LogContainerCmd logCmd,
-                  @Mock WaitContainerCmd waitCmd,
-                  @Mock WaitContainerResultCallback waitResult,
-                  @Mock Logger logger
-                  ) {
-        
-        String  PLATFORM_LEVEL="0.7";
-        String  LOG_LEVEL="debug";
-        String  CONTAINER_ID="999";
-        int     CONTAINER_RC=99;
-        int     USER_ID=77;
-        int     GROUP_ID=88;
-        String  OUTPUT_IMAGE="stiletto";
-        boolean USE_DAEMON=false;
+    @Mock LifecyclePhaseFactory factory;
+    @Mock BuilderImage builder;
+    @Mock LogConfig logConfig;
+    @Mock DockerConfig dockerConfig;
+    @Mock DockerClient dockerClient;
+    @Mock StartContainerCmd startCmd;
+    @Mock LogContainerCmd logCmd;
+    @Mock WaitContainerCmd waitCmd;
+    @Mock WaitContainerResultCallback waitResult;
+    @Mock Logger logger;
 
+    @BeforeEach
+    void setUp() {
         lenient().when(dockerConfig.getUseDaemon()).thenReturn(USE_DAEMON);
         lenient().when(dockerConfig.getDockerClient()).thenReturn(dockerClient);        
         lenient().when(factory.getDockerConfig()).thenReturn(dockerConfig);
@@ -90,11 +90,14 @@ public class BuilderTest {
         lenient().when(builder.getRunImages(any())).thenReturn(Stream.of(new ImageReference("runimage1"), new ImageReference("runimage2")).collect(Collectors.toList()).toArray(new ImageReference[]{}));        
         lenient().when(factory.getBuilderImage()).thenReturn(builder);
 
-        lenient().when(factory.getPlatformLevel()).thenReturn(new Version(PLATFORM_LEVEL));
-
         lenient().when(factory.getContainerForPhase(argsCaptor.capture(), any())).thenReturn(CONTAINER_ID);
 
         lenient().when(factory.getOutputImage()).thenReturn(new ImageReference(OUTPUT_IMAGE));
+    }
+
+    @Test
+    void testBuilder() {
+        lenient().when(factory.getPlatformLevel()).thenReturn(new Version("0.7"));
 
         Builder b = new Builder(factory);
 
@@ -106,12 +109,10 @@ public class BuilderTest {
 
         String[] args = argsCaptor.getValue();
         assertNotNull(args);
-        //verify 1st & last elements
         assertEquals("/cnb/lifecycle/builder", args[0]);
         assertNotEquals(args[args.length-1], OUTPUT_IMAGE);
 
         List<String> argList = Arrays.asList(args);
-        //verify log as expected
         assertTrue(argList.contains(LOG_LEVEL));
 
         verify(logCmd).withTimestamps(true);
@@ -120,59 +121,8 @@ public class BuilderTest {
     }
 
     @Test
-    void testDisableTimestamps(@Mock LifecyclePhaseFactory factory, 
-                  @Mock BuilderImage builder, 
-                  @Mock LogConfig logConfig, 
-                  @Mock DockerConfig dockerConfig, 
-                  @Mock DockerClient dockerClient,
-                  @Mock StartContainerCmd startCmd,
-                  @Mock LogContainerCmd logCmd,
-                  @Mock WaitContainerCmd waitCmd,
-                  @Mock WaitContainerResultCallback waitResult,
-                  @Mock Logger logger
-                  ) 
-    {
-        
-        String  PLATFORM_LEVEL="0.9";
-        String  LOG_LEVEL="debug";
-        String  CONTAINER_ID="999";
-        int     CONTAINER_RC=99;
-        int     USER_ID=77;
-        int     GROUP_ID=88;
-        String  OUTPUT_IMAGE="stiletto";
-        boolean USE_DAEMON=false;
-
-        lenient().when(dockerConfig.getUseDaemon()).thenReturn(USE_DAEMON);
-        lenient().when(dockerConfig.getDockerClient()).thenReturn(dockerClient);        
-        lenient().when(factory.getDockerConfig()).thenReturn(dockerConfig);
-
-        lenient().doNothing().when(startCmd).exec();
-        lenient().when(dockerClient.startContainerCmd(any())).thenReturn(startCmd);
-
-        lenient().when(logCmd.withFollowStream(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withStdOut(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withStdErr(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withTimestamps(any())).thenReturn(logCmd);
-        lenient().when(logCmd.exec(any())).thenReturn(null);
-        lenient().when(dockerClient.logContainerCmd(any())).thenReturn(logCmd);
-
-        lenient().when(waitCmd.exec(any())).thenReturn(waitResult);
-        lenient().when(waitResult.awaitStatusCode()).thenReturn(CONTAINER_RC);
-        lenient().when(dockerClient.waitContainerCmd(any())).thenReturn(waitCmd);
-
-        lenient().when(logConfig.getLogLevel()).thenReturn(LOG_LEVEL);
-        lenient().when(factory.getLogConfig()).thenReturn(logConfig);
-
-        lenient().when(builder.getUserId()).thenReturn(USER_ID);
-        lenient().when(builder.getGroupId()).thenReturn(GROUP_ID);
-        lenient().when(builder.getRunImages(any())).thenReturn(Stream.of(new ImageReference("runimage1"), new ImageReference("runimage2")).collect(Collectors.toList()).toArray(new ImageReference[]{}));
-        lenient().when(factory.getBuilderImage()).thenReturn(builder);
-
-        lenient().when(factory.getPlatformLevel()).thenReturn(new Version(PLATFORM_LEVEL));
-
-        lenient().when(factory.getContainerForPhase(argsCaptor.capture(), any())).thenReturn(CONTAINER_ID);
-
-        lenient().when(factory.getOutputImage()).thenReturn(new ImageReference(OUTPUT_IMAGE));
+    void testDisableTimestamps() {
+        lenient().when(factory.getPlatformLevel()).thenReturn(new Version("0.9"));
 
         Builder b = new Builder(factory);
 
@@ -184,12 +134,10 @@ public class BuilderTest {
 
         String[] args = argsCaptor.getValue();
         assertNotNull(args);
-        //verify 1st & last elements
         assertEquals("/cnb/lifecycle/builder", args[0]);
         assertNotEquals(args[args.length-1], OUTPUT_IMAGE);
 
         List<String> argList = Arrays.asList(args);
-        //verify log as expected
         assertTrue(argList.contains(LOG_LEVEL));
 
         verify(logCmd).withTimestamps(false);

--- a/client/src/test/java/dev/snowdrop/buildpack/lifecycle/phases/CreatorTest.java
+++ b/client/src/test/java/dev/snowdrop/buildpack/lifecycle/phases/CreatorTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -39,31 +40,30 @@ import dev.snowdrop.buildpack.lifecycle.Version;
 @ExtendWith(MockitoExtension.class)
 public class CreatorTest {
 
+    private static final String LOG_LEVEL = "debug";
+    private static final String CONTAINER_ID = "999";
+    private static final int CONTAINER_RC = 99;
+    private static final int USER_ID = 77;
+    private static final int GROUP_ID = 88;
+    private static final String OUTPUT_IMAGE = "stiletto";
+    private static final boolean USE_DAEMON = false;
+
     @Captor
     ArgumentCaptor<String[]> argsCaptor;
 
-    @Test
-    void testPre9(@Mock LifecyclePhaseFactory factory, 
-                  @Mock BuilderImage builder, 
-                  @Mock LogConfig logConfig, 
-                  @Mock DockerConfig dockerConfig, 
-                  @Mock DockerClient dockerClient,
-                  @Mock StartContainerCmd startCmd,
-                  @Mock LogContainerCmd logCmd,
-                  @Mock WaitContainerCmd waitCmd,
-                  @Mock WaitContainerResultCallback waitResult,
-                  @Mock Logger logger
-                  ) {
-        
-        String  PLATFORM_LEVEL="0.7";
-        String  LOG_LEVEL="debug";
-        String  CONTAINER_ID="999";
-        int     CONTAINER_RC=99;
-        int     USER_ID=77;
-        int     GROUP_ID=88;
-        String  OUTPUT_IMAGE="stiletto";
-        boolean USE_DAEMON=false;
+    @Mock LifecyclePhaseFactory factory;
+    @Mock BuilderImage builder;
+    @Mock LogConfig logConfig;
+    @Mock DockerConfig dockerConfig;
+    @Mock DockerClient dockerClient;
+    @Mock StartContainerCmd startCmd;
+    @Mock LogContainerCmd logCmd;
+    @Mock WaitContainerCmd waitCmd;
+    @Mock WaitContainerResultCallback waitResult;
+    @Mock Logger logger;
 
+    @BeforeEach
+    void setUp() {
         lenient().when(dockerConfig.getUseDaemon()).thenReturn(USE_DAEMON);
         lenient().when(dockerConfig.getDockerClient()).thenReturn(dockerClient);        
         lenient().when(factory.getDockerConfig()).thenReturn(dockerConfig);
@@ -90,11 +90,14 @@ public class CreatorTest {
         lenient().when(builder.getRunImages(any())).thenReturn(Stream.of(new ImageReference("runimage1"), new ImageReference("runimage2")).collect(Collectors.toList()).toArray(new ImageReference[]{}));        
         lenient().when(factory.getBuilderImage()).thenReturn(builder);
 
-        lenient().when(factory.getPlatformLevel()).thenReturn(new Version(PLATFORM_LEVEL));
-
         lenient().when(factory.getContainerForPhase(argsCaptor.capture(), any())).thenReturn(CONTAINER_ID);
 
         lenient().when(factory.getOutputImage()).thenReturn(new ImageReference(OUTPUT_IMAGE));
+    }
+
+    @Test
+    void testPre9() {
+        lenient().when(factory.getPlatformLevel()).thenReturn(new Version("0.7"));
 
         Creator c = new Creator(factory);
 
@@ -106,16 +109,12 @@ public class CreatorTest {
 
         String[] args = argsCaptor.getValue();
         assertNotNull(args);
-        //verify 1st & last elements
         assertEquals("/cnb/lifecycle/creator", args[0]);
         assertEquals(new ImageReference(OUTPUT_IMAGE).getReferenceWithLatest(), args[args.length-1]);        
 
         List<String> argList = Arrays.asList(args);
-        //verify no launch cache for a pre7 run
         assertFalse(argList.contains("-launch-cache"));
-        //verify no dameon
         assertFalse(argList.contains("-daemon"));
-        //verify log as expected
         assertTrue(argList.contains(LOG_LEVEL));
 
         verify(logCmd).withTimestamps(true);
@@ -124,59 +123,8 @@ public class CreatorTest {
     }
 
     @Test
-    void testDisableTimestamps(@Mock LifecyclePhaseFactory factory, 
-                  @Mock BuilderImage builder, 
-                  @Mock LogConfig logConfig, 
-                  @Mock DockerConfig dockerConfig, 
-                  @Mock DockerClient dockerClient,
-                  @Mock StartContainerCmd startCmd,
-                  @Mock LogContainerCmd logCmd,
-                  @Mock WaitContainerCmd waitCmd,
-                  @Mock WaitContainerResultCallback waitResult,
-                  @Mock Logger logger
-                  ) 
-    {
-        
-        String  PLATFORM_LEVEL="0.9";
-        String  LOG_LEVEL="debug";
-        String  CONTAINER_ID="999";
-        int     CONTAINER_RC=99;
-        int     USER_ID=77;
-        int     GROUP_ID=88;
-        String  OUTPUT_IMAGE="stiletto";
-        boolean USE_DAEMON=false;
-
-        lenient().when(dockerConfig.getUseDaemon()).thenReturn(USE_DAEMON);
-        lenient().when(dockerConfig.getDockerClient()).thenReturn(dockerClient);        
-        lenient().when(factory.getDockerConfig()).thenReturn(dockerConfig);
-
-        lenient().doNothing().when(startCmd).exec();
-        lenient().when(dockerClient.startContainerCmd(any())).thenReturn(startCmd);
-
-        lenient().when(logCmd.withFollowStream(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withStdOut(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withStdErr(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withTimestamps(any())).thenReturn(logCmd);
-        lenient().when(logCmd.exec(any())).thenReturn(null);
-        lenient().when(dockerClient.logContainerCmd(any())).thenReturn(logCmd);
-
-        lenient().when(waitCmd.exec(any())).thenReturn(waitResult);
-        lenient().when(waitResult.awaitStatusCode()).thenReturn(CONTAINER_RC);
-        lenient().when(dockerClient.waitContainerCmd(any())).thenReturn(waitCmd);
-
-        lenient().when(logConfig.getLogLevel()).thenReturn(LOG_LEVEL);
-        lenient().when(factory.getLogConfig()).thenReturn(logConfig);
-
-        lenient().when(builder.getUserId()).thenReturn(USER_ID);
-        lenient().when(builder.getGroupId()).thenReturn(GROUP_ID);
-        lenient().when(builder.getRunImages(any())).thenReturn(Stream.of(new ImageReference("runimage1"), new ImageReference("runimage2")).collect(Collectors.toList()).toArray(new ImageReference[]{}));
-        lenient().when(factory.getBuilderImage()).thenReturn(builder);
-
-        lenient().when(factory.getPlatformLevel()).thenReturn(new Version(PLATFORM_LEVEL));
-
-        lenient().when(factory.getContainerForPhase(argsCaptor.capture(), any())).thenReturn(CONTAINER_ID);
-
-        lenient().when(factory.getOutputImage()).thenReturn(new ImageReference(OUTPUT_IMAGE));
+    void testDisableTimestamps() {
+        lenient().when(factory.getPlatformLevel()).thenReturn(new Version("0.9"));
 
         Creator c = new Creator(factory);
 
@@ -188,17 +136,12 @@ public class CreatorTest {
 
         String[] args = argsCaptor.getValue();
         assertNotNull(args);
-        //verify 1st & last elements
         assertEquals("/cnb/lifecycle/creator", args[0]);
         assertEquals(new ImageReference(OUTPUT_IMAGE).getReferenceWithLatest(), args[args.length-1]);        
 
         List<String> argList = Arrays.asList(args);
-        //verify launch cache for a 9 onwards run 
-        //launch cache only valid with daemon mode.
         assertFalse(argList.contains("-launch-cache"));
-        //verify dameon
         assertFalse(argList.contains("-daemon"));
-        //verify log as expected
         assertTrue(argList.contains(LOG_LEVEL));
 
         verify(logCmd).withTimestamps(false);
@@ -207,59 +150,8 @@ public class CreatorTest {
     }  
 
     @Test
-    void test9OnwardsWithoutDaemon(@Mock LifecyclePhaseFactory factory, 
-                  @Mock BuilderImage builder, 
-                  @Mock LogConfig logConfig, 
-                  @Mock DockerConfig dockerConfig, 
-                  @Mock DockerClient dockerClient,
-                  @Mock StartContainerCmd startCmd,
-                  @Mock LogContainerCmd logCmd,
-                  @Mock WaitContainerCmd waitCmd,
-                  @Mock WaitContainerResultCallback waitResult,
-                  @Mock Logger logger
-                  ) 
-    {
-        
-        String  PLATFORM_LEVEL="0.9";
-        String  LOG_LEVEL="debug";
-        String  CONTAINER_ID="999";
-        int     CONTAINER_RC=99;
-        int     USER_ID=77;
-        int     GROUP_ID=88;
-        String  OUTPUT_IMAGE="stiletto";
-        boolean USE_DAEMON=false;
-
-        lenient().when(dockerConfig.getUseDaemon()).thenReturn(USE_DAEMON);
-        lenient().when(dockerConfig.getDockerClient()).thenReturn(dockerClient);        
-        lenient().when(factory.getDockerConfig()).thenReturn(dockerConfig);
-
-        lenient().doNothing().when(startCmd).exec();
-        lenient().when(dockerClient.startContainerCmd(any())).thenReturn(startCmd);
-
-        lenient().when(logCmd.withFollowStream(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withStdOut(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withStdErr(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withTimestamps(any())).thenReturn(logCmd);
-        lenient().when(logCmd.exec(any())).thenReturn(null);
-        lenient().when(dockerClient.logContainerCmd(any())).thenReturn(logCmd);
-
-        lenient().when(waitCmd.exec(any())).thenReturn(waitResult);
-        lenient().when(waitResult.awaitStatusCode()).thenReturn(CONTAINER_RC);
-        lenient().when(dockerClient.waitContainerCmd(any())).thenReturn(waitCmd);
-
-        lenient().when(logConfig.getLogLevel()).thenReturn(LOG_LEVEL);
-        lenient().when(factory.getLogConfig()).thenReturn(logConfig);
-
-        lenient().when(builder.getUserId()).thenReturn(USER_ID);
-        lenient().when(builder.getGroupId()).thenReturn(GROUP_ID);
-        lenient().when(builder.getRunImages(any())).thenReturn(Stream.of(new ImageReference("runimage1"), new ImageReference("runimage2")).collect(Collectors.toList()).toArray(new ImageReference[]{}));        
-        lenient().when(factory.getBuilderImage()).thenReturn(builder);
-
-        lenient().when(factory.getPlatformLevel()).thenReturn(new Version(PLATFORM_LEVEL));
-
-        lenient().when(factory.getContainerForPhase(argsCaptor.capture(), any())).thenReturn(CONTAINER_ID);
-
-        lenient().when(factory.getOutputImage()).thenReturn(new ImageReference(OUTPUT_IMAGE));
+    void test9OnwardsWithoutDaemon() {
+        lenient().when(factory.getPlatformLevel()).thenReturn(new Version("0.9"));
 
         Creator c = new Creator(factory);
 
@@ -271,17 +163,12 @@ public class CreatorTest {
 
         String[] args = argsCaptor.getValue();
         assertNotNull(args);
-        //verify 1st & last elements
         assertEquals("/cnb/lifecycle/creator", args[0]);
         assertEquals(new ImageReference(OUTPUT_IMAGE).getReferenceWithLatest(), args[args.length-1]);        
 
         List<String> argList = Arrays.asList(args);
-        //verify launch cache for a 9 onwards run 
-        //launch cache only valid with daemon mode.
         assertFalse(argList.contains("-launch-cache"));
-        //verify dameon
         assertFalse(argList.contains("-daemon"));
-        //verify log as expected
         assertTrue(argList.contains(LOG_LEVEL));
 
         verify(logCmd).withTimestamps(true);
@@ -290,59 +177,9 @@ public class CreatorTest {
     }     
 
     @Test
-    void test9OnwardsWithDaemon(@Mock LifecyclePhaseFactory factory, 
-                  @Mock BuilderImage builder, 
-                  @Mock LogConfig logConfig, 
-                  @Mock DockerConfig dockerConfig, 
-                  @Mock DockerClient dockerClient,
-                  @Mock StartContainerCmd startCmd,
-                  @Mock LogContainerCmd logCmd,
-                  @Mock WaitContainerCmd waitCmd,
-                  @Mock WaitContainerResultCallback waitResult,
-                  @Mock Logger logger
-                  ) 
-    {
-        
-        String  PLATFORM_LEVEL="0.9";
-        String  LOG_LEVEL="debug";
-        String  CONTAINER_ID="999";
-        int     CONTAINER_RC=99;
-        int     USER_ID=77;
-        int     GROUP_ID=88;
-        String  OUTPUT_IMAGE="stiletto";
-        boolean USE_DAEMON=true;
-
-        lenient().when(dockerConfig.getUseDaemon()).thenReturn(USE_DAEMON);
-        lenient().when(dockerConfig.getDockerClient()).thenReturn(dockerClient);        
-        lenient().when(factory.getDockerConfig()).thenReturn(dockerConfig);
-
-        lenient().doNothing().when(startCmd).exec();
-        lenient().when(dockerClient.startContainerCmd(any())).thenReturn(startCmd);
-
-        lenient().when(logCmd.withFollowStream(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withStdOut(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withStdErr(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withTimestamps(any())).thenReturn(logCmd);
-        lenient().when(logCmd.exec(any())).thenReturn(null);
-        lenient().when(dockerClient.logContainerCmd(any())).thenReturn(logCmd);
-
-        lenient().when(waitCmd.exec(any())).thenReturn(waitResult);
-        lenient().when(waitResult.awaitStatusCode()).thenReturn(CONTAINER_RC);
-        lenient().when(dockerClient.waitContainerCmd(any())).thenReturn(waitCmd);
-
-        lenient().when(logConfig.getLogLevel()).thenReturn(LOG_LEVEL);
-        lenient().when(factory.getLogConfig()).thenReturn(logConfig);
-
-        lenient().when(builder.getUserId()).thenReturn(USER_ID);
-        lenient().when(builder.getGroupId()).thenReturn(GROUP_ID);
-        lenient().when(builder.getRunImages(any())).thenReturn(Stream.of(new ImageReference("runimage1"), new ImageReference("runimage2")).collect(Collectors.toList()).toArray(new ImageReference[]{}));
-        lenient().when(factory.getBuilderImage()).thenReturn(builder);
-
-        lenient().when(factory.getPlatformLevel()).thenReturn(new Version(PLATFORM_LEVEL));
-
-        lenient().when(factory.getContainerForPhase(argsCaptor.capture(), any())).thenReturn(CONTAINER_ID);
-
-        lenient().when(factory.getOutputImage()).thenReturn(new ImageReference(OUTPUT_IMAGE));
+    void test9OnwardsWithDaemon() {
+        lenient().when(dockerConfig.getUseDaemon()).thenReturn(true);
+        lenient().when(factory.getPlatformLevel()).thenReturn(new Version("0.9"));
 
         Creator c = new Creator(factory);
 
@@ -354,16 +191,12 @@ public class CreatorTest {
 
         String[] args = argsCaptor.getValue();
         assertNotNull(args);
-        //verify 1st & last elements
         assertEquals("/cnb/lifecycle/creator", args[0]);
         assertEquals(new ImageReference(OUTPUT_IMAGE).getReferenceWithLatest(), args[args.length-1]);
 
         List<String> argList = Arrays.asList(args);
-        //verify launch cache for a 9 onwards run
         assertTrue(argList.contains("-launch-cache"));
-        //verify dameon
         assertTrue(argList.contains("-daemon"));
-        //verify log as expected
         assertTrue(argList.contains(LOG_LEVEL));
 
         verify(logCmd).withTimestamps(true);

--- a/client/src/test/java/dev/snowdrop/buildpack/lifecycle/phases/DetectorTest.java
+++ b/client/src/test/java/dev/snowdrop/buildpack/lifecycle/phases/DetectorTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -43,33 +44,31 @@ import dev.snowdrop.buildpack.lifecycle.Version;
 @ExtendWith(MockitoExtension.class)
 public class DetectorTest {
 
+    private static final String LOG_LEVEL = "debug";
+    private static final String CONTAINER_ID = "999";
+    private static final int CONTAINER_RC = 99;
+    private static final int USER_ID = 77;
+    private static final int GROUP_ID = 88;
+    private static final String OUTPUT_IMAGE = "stiletto";
+    private static final boolean USE_DAEMON = false;
+    private static final boolean HAS_EXTENSIONS = true;
+
     @Captor
     ArgumentCaptor<String[]> argsCaptor;
 
-    @SuppressWarnings("resource")
-    @Test
-    void testPre10(@Mock LifecyclePhaseFactory factory, 
-                  @Mock BuilderImage builder, 
-                  @Mock LogConfig logConfig, 
-                  @Mock DockerConfig dockerConfig, 
-                  @Mock DockerClient dockerClient,
-                  @Mock StartContainerCmd startCmd,
-                  @Mock LogContainerCmd logCmd,
-                  @Mock WaitContainerCmd waitCmd,
-                  @Mock WaitContainerResultCallback waitResult,
-                  @Mock Logger logger
-                  ) {
-        
-        String  PLATFORM_LEVEL="0.7";
-        String  LOG_LEVEL="debug";
-        String  CONTAINER_ID="999";
-        int     CONTAINER_RC=99;
-        int     USER_ID=77;
-        int     GROUP_ID=88;
-        String  OUTPUT_IMAGE="stiletto";
-        boolean USE_DAEMON=false;
-        boolean HAS_EXTENSIONS=false; 
+    @Mock LifecyclePhaseFactory factory;
+    @Mock BuilderImage builder;
+    @Mock LogConfig logConfig;
+    @Mock DockerConfig dockerConfig;
+    @Mock DockerClient dockerClient;
+    @Mock StartContainerCmd startCmd;
+    @Mock LogContainerCmd logCmd;
+    @Mock WaitContainerCmd waitCmd;
+    @Mock WaitContainerResultCallback waitResult;
+    @Mock Logger logger;
 
+    @BeforeEach
+    void setUp() {
         lenient().when(dockerConfig.getUseDaemon()).thenReturn(USE_DAEMON);
         lenient().when(dockerConfig.getDockerClient()).thenReturn(dockerClient);        
         lenient().when(factory.getDockerConfig()).thenReturn(dockerConfig);
@@ -97,15 +96,19 @@ public class DetectorTest {
         lenient().when(builder.hasExtensions()).thenReturn(HAS_EXTENSIONS);
         lenient().when(factory.getBuilderImage()).thenReturn(builder);
 
-        lenient().when(factory.getPlatformLevel()).thenReturn(new Version(PLATFORM_LEVEL));
-
         lenient().when(factory.getContainerForPhase(argsCaptor.capture(), any())).thenReturn(CONTAINER_ID);
 
         lenient().when(factory.getOutputImage()).thenReturn(new ImageReference(OUTPUT_IMAGE));
+    }
+
+    @SuppressWarnings("resource")
+    @Test
+    void testPre10() {
+        lenient().when(builder.hasExtensions()).thenReturn(false);
+        lenient().when(factory.getPlatformLevel()).thenReturn(new Version("0.7"));
 
         try (MockedStatic<? extends ContainerUtils> containerUtils = mockStatic(ContainerUtils.class)) {
             Detector d = new Detector(factory);
-
             containerUtils.when(() -> ContainerUtils.getFileFromContainer(eq(dockerClient), any(), any())).thenReturn("EmptyTOML".getBytes());
 
             ContainerStatus cs = d.runPhase(logger, true);
@@ -113,22 +116,17 @@ public class DetectorTest {
             assertNotNull(cs);
             assertEquals(CONTAINER_ID, cs.getContainerId());
             assertEquals(CONTAINER_RC, cs.getRc());
-
             assertEquals("EmptyTOML", new String(d.getAnalyzedToml()));
         }
 
         String[] args = argsCaptor.getValue();
         assertNotNull(args);
-        //verify 1st & last elements
         assertEquals("/cnb/lifecycle/detector", args[0]);
         assertNotEquals(args[args.length-1], OUTPUT_IMAGE);
 
         List<String> argList = Arrays.asList(args);
-        //verify no generated for a pre 0.10 run.
         assertFalse(argList.contains("-generated"));
-        //verify no dameon
         assertFalse(argList.contains("-daemon"));
-        //verify log as expected
         assertTrue(argList.contains(LOG_LEVEL));
 
         verify(logCmd).withTimestamps(true);
@@ -138,64 +136,11 @@ public class DetectorTest {
 
     @SuppressWarnings("resource")
     @Test
-    void testPre10WithExtensions(@Mock LifecyclePhaseFactory factory, 
-                  @Mock BuilderImage builder, 
-                  @Mock LogConfig logConfig, 
-                  @Mock DockerConfig dockerConfig, 
-                  @Mock DockerClient dockerClient,
-                  @Mock StartContainerCmd startCmd,
-                  @Mock LogContainerCmd logCmd,
-                  @Mock WaitContainerCmd waitCmd,
-                  @Mock WaitContainerResultCallback waitResult,
-                  @Mock Logger logger
-                  ) {
-        
-        String  PLATFORM_LEVEL="0.7";
-        String  LOG_LEVEL="debug";
-        String  CONTAINER_ID="999";
-        int     CONTAINER_RC=99;
-        int     USER_ID=77;
-        int     GROUP_ID=88;
-        String  OUTPUT_IMAGE="stiletto";
-        boolean USE_DAEMON=false;
-        boolean HAS_EXTENSIONS=true; 
-
-        lenient().when(dockerConfig.getUseDaemon()).thenReturn(USE_DAEMON);
-        lenient().when(dockerConfig.getDockerClient()).thenReturn(dockerClient);        
-        lenient().when(factory.getDockerConfig()).thenReturn(dockerConfig);
-
-        lenient().doNothing().when(startCmd).exec();
-        lenient().when(dockerClient.startContainerCmd(any())).thenReturn(startCmd);
-
-        lenient().when(logCmd.withFollowStream(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withStdOut(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withStdErr(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withTimestamps(any())).thenReturn(logCmd);
-        lenient().when(logCmd.exec(any())).thenReturn(null);
-        lenient().when(dockerClient.logContainerCmd(any())).thenReturn(logCmd);
-
-        lenient().when(waitCmd.exec(any())).thenReturn(waitResult);
-        lenient().when(waitResult.awaitStatusCode()).thenReturn(CONTAINER_RC);
-        lenient().when(dockerClient.waitContainerCmd(any())).thenReturn(waitCmd);
-
-        lenient().when(logConfig.getLogLevel()).thenReturn(LOG_LEVEL);
-        lenient().when(factory.getLogConfig()).thenReturn(logConfig);
-
-        lenient().when(builder.getUserId()).thenReturn(USER_ID);
-        lenient().when(builder.getGroupId()).thenReturn(GROUP_ID);
-        lenient().when(builder.getRunImages(any())).thenReturn(Stream.of(new ImageReference("runimage1"), new ImageReference("runimage2")).collect(Collectors.toList()).toArray(new ImageReference[]{}));
-        lenient().when(builder.hasExtensions()).thenReturn(HAS_EXTENSIONS);
-        lenient().when(factory.getBuilderImage()).thenReturn(builder);
-
-        lenient().when(factory.getPlatformLevel()).thenReturn(new Version(PLATFORM_LEVEL));
-
-        lenient().when(factory.getContainerForPhase(argsCaptor.capture(), any())).thenReturn(CONTAINER_ID);
-
-        lenient().when(factory.getOutputImage()).thenReturn(new ImageReference(OUTPUT_IMAGE));
+    void testPre10WithExtensions() {
+        lenient().when(factory.getPlatformLevel()).thenReturn(new Version("0.7"));
 
         try (MockedStatic<? extends ContainerUtils> containerUtils = mockStatic(ContainerUtils.class)) {
             Detector d = new Detector(factory);
-
             containerUtils.when(() -> ContainerUtils.getFileFromContainer(eq(dockerClient), any(), any())).thenReturn("EmptyTOML".getBytes());
 
             ContainerStatus cs = d.runPhase(logger, true);
@@ -203,22 +148,17 @@ public class DetectorTest {
             assertNotNull(cs);
             assertEquals(CONTAINER_ID, cs.getContainerId());
             assertEquals(CONTAINER_RC, cs.getRc());
-
             assertEquals("EmptyTOML", new String(d.getAnalyzedToml()));
         }
 
         String[] args = argsCaptor.getValue();
         assertNotNull(args);
-        //verify 1st & last elements
         assertEquals("/cnb/lifecycle/detector", args[0]);
         assertNotEquals(args[args.length-1], OUTPUT_IMAGE);
 
         List<String> argList = Arrays.asList(args);
-        //verify no generated for a pre 0.10 run.
         assertFalse(argList.contains("-generated"));
-        //verify no dameon
         assertFalse(argList.contains("-daemon"));
-        //verify log as expected
         assertTrue(argList.contains(LOG_LEVEL));
 
         verify(logCmd).withTimestamps(true);
@@ -228,64 +168,11 @@ public class DetectorTest {
     
     @SuppressWarnings("resource")
     @Test
-    void test10WithExtensions(@Mock LifecyclePhaseFactory factory, 
-                  @Mock BuilderImage builder, 
-                  @Mock LogConfig logConfig, 
-                  @Mock DockerConfig dockerConfig, 
-                  @Mock DockerClient dockerClient,
-                  @Mock StartContainerCmd startCmd,
-                  @Mock LogContainerCmd logCmd,
-                  @Mock WaitContainerCmd waitCmd,
-                  @Mock WaitContainerResultCallback waitResult,
-                  @Mock Logger logger
-                  ) {
-        
-        String  PLATFORM_LEVEL="0.10";
-        String  LOG_LEVEL="debug";
-        String  CONTAINER_ID="999";
-        int     CONTAINER_RC=99;
-        int     USER_ID=77;
-        int     GROUP_ID=88;
-        String  OUTPUT_IMAGE="stiletto";
-        boolean USE_DAEMON=false;
-        boolean HAS_EXTENSIONS=true; 
-
-        lenient().when(dockerConfig.getUseDaemon()).thenReturn(USE_DAEMON);
-        lenient().when(dockerConfig.getDockerClient()).thenReturn(dockerClient);        
-        lenient().when(factory.getDockerConfig()).thenReturn(dockerConfig);
-
-        lenient().doNothing().when(startCmd).exec();
-        lenient().when(dockerClient.startContainerCmd(any())).thenReturn(startCmd);
-
-        lenient().when(logCmd.withFollowStream(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withStdOut(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withStdErr(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withTimestamps(any())).thenReturn(logCmd);
-        lenient().when(logCmd.exec(any())).thenReturn(null);
-        lenient().when(dockerClient.logContainerCmd(any())).thenReturn(logCmd);
-
-        lenient().when(waitCmd.exec(any())).thenReturn(waitResult);
-        lenient().when(waitResult.awaitStatusCode()).thenReturn(CONTAINER_RC);
-        lenient().when(dockerClient.waitContainerCmd(any())).thenReturn(waitCmd);
-
-        lenient().when(logConfig.getLogLevel()).thenReturn(LOG_LEVEL);
-        lenient().when(factory.getLogConfig()).thenReturn(logConfig);
-
-        lenient().when(builder.getUserId()).thenReturn(USER_ID);
-        lenient().when(builder.getGroupId()).thenReturn(GROUP_ID);
-        lenient().when(builder.getRunImages(any())).thenReturn(Stream.of(new ImageReference("runimage1"), new ImageReference("runimage2")).collect(Collectors.toList()).toArray(new ImageReference[]{}));
-        lenient().when(builder.hasExtensions()).thenReturn(HAS_EXTENSIONS);
-        lenient().when(factory.getBuilderImage()).thenReturn(builder);
-
-        lenient().when(factory.getPlatformLevel()).thenReturn(new Version(PLATFORM_LEVEL));
-
-        lenient().when(factory.getContainerForPhase(argsCaptor.capture(), any())).thenReturn(CONTAINER_ID);
-
-        lenient().when(factory.getOutputImage()).thenReturn(new ImageReference(OUTPUT_IMAGE));
+    void test10WithExtensions() {
+        lenient().when(factory.getPlatformLevel()).thenReturn(new Version("0.10"));
 
         try (MockedStatic<? extends ContainerUtils> containerUtils = mockStatic(ContainerUtils.class)) {
             Detector d = new Detector(factory);
-
             containerUtils.when(() -> ContainerUtils.getFileFromContainer(eq(dockerClient), any(), any())).thenReturn("EmptyTOML".getBytes());
 
             ContainerStatus cs = d.runPhase(logger, true);
@@ -293,22 +180,17 @@ public class DetectorTest {
             assertNotNull(cs);
             assertEquals(CONTAINER_ID, cs.getContainerId());
             assertEquals(CONTAINER_RC, cs.getRc());
-
             assertEquals("EmptyTOML", new String(d.getAnalyzedToml()));
         }
 
         String[] args = argsCaptor.getValue();
         assertNotNull(args);
-        //verify 1st & last elements
         assertEquals("/cnb/lifecycle/detector", args[0]);
         assertNotEquals(args[args.length-1], OUTPUT_IMAGE);
 
         List<String> argList = Arrays.asList(args);
-        //verify  generated for a 0.10 run with extensions
         assertTrue(argList.contains("-generated"));
-        //verify no dameon
         assertFalse(argList.contains("-daemon"));
-        //verify log as expected
         assertTrue(argList.contains(LOG_LEVEL));
 
         verify(logCmd).withTimestamps(true);
@@ -318,64 +200,11 @@ public class DetectorTest {
 
     @SuppressWarnings("resource")
     @Test
-    void test12WithExtensions(@Mock LifecyclePhaseFactory factory, 
-                  @Mock BuilderImage builder, 
-                  @Mock LogConfig logConfig, 
-                  @Mock DockerConfig dockerConfig, 
-                  @Mock DockerClient dockerClient,
-                  @Mock StartContainerCmd startCmd,
-                  @Mock LogContainerCmd logCmd,
-                  @Mock WaitContainerCmd waitCmd,
-                  @Mock WaitContainerResultCallback waitResult,
-                  @Mock Logger logger
-                  ) {
-        
-        String  PLATFORM_LEVEL="0.12";
-        String  LOG_LEVEL="debug";
-        String  CONTAINER_ID="999";
-        int     CONTAINER_RC=99;
-        int     USER_ID=77;
-        int     GROUP_ID=88;
-        String  OUTPUT_IMAGE="stiletto";
-        boolean USE_DAEMON=false;
-        boolean HAS_EXTENSIONS=true; 
-
-        lenient().when(dockerConfig.getUseDaemon()).thenReturn(USE_DAEMON);
-        lenient().when(dockerConfig.getDockerClient()).thenReturn(dockerClient);        
-        lenient().when(factory.getDockerConfig()).thenReturn(dockerConfig);
-
-        lenient().doNothing().when(startCmd).exec();
-        lenient().when(dockerClient.startContainerCmd(any())).thenReturn(startCmd);
-
-        lenient().when(logCmd.withFollowStream(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withStdOut(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withStdErr(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withTimestamps(any())).thenReturn(logCmd);
-        lenient().when(logCmd.exec(any())).thenReturn(null);
-        lenient().when(dockerClient.logContainerCmd(any())).thenReturn(logCmd);
-
-        lenient().when(waitCmd.exec(any())).thenReturn(waitResult);
-        lenient().when(waitResult.awaitStatusCode()).thenReturn(CONTAINER_RC);
-        lenient().when(dockerClient.waitContainerCmd(any())).thenReturn(waitCmd);
-
-        lenient().when(logConfig.getLogLevel()).thenReturn(LOG_LEVEL);
-        lenient().when(factory.getLogConfig()).thenReturn(logConfig);
-
-        lenient().when(builder.getUserId()).thenReturn(USER_ID);
-        lenient().when(builder.getGroupId()).thenReturn(GROUP_ID);
-        lenient().when(builder.getRunImages(any())).thenReturn(Stream.of(new ImageReference("runimage1"), new ImageReference("runimage2")).collect(Collectors.toList()).toArray(new ImageReference[]{}));
-        lenient().when(builder.hasExtensions()).thenReturn(HAS_EXTENSIONS);
-        lenient().when(factory.getBuilderImage()).thenReturn(builder);
-
-        lenient().when(factory.getPlatformLevel()).thenReturn(new Version(PLATFORM_LEVEL));
-
-        lenient().when(factory.getContainerForPhase(argsCaptor.capture(), any())).thenReturn(CONTAINER_ID);
-
-        lenient().when(factory.getOutputImage()).thenReturn(new ImageReference(OUTPUT_IMAGE));
+    void test12WithExtensions() {
+        lenient().when(factory.getPlatformLevel()).thenReturn(new Version("0.12"));
 
         try (MockedStatic<? extends ContainerUtils> containerUtils = mockStatic(ContainerUtils.class)) {
             Detector d = new Detector(factory);
-
             containerUtils.when(() -> ContainerUtils.getFileFromContainer(eq(dockerClient), any(), any())).thenReturn("EmptyTOML".getBytes());
 
             ContainerStatus cs = d.runPhase(logger, true);
@@ -383,24 +212,18 @@ public class DetectorTest {
             assertNotNull(cs);
             assertEquals(CONTAINER_ID, cs.getContainerId());
             assertEquals(CONTAINER_RC, cs.getRc());
-
             assertEquals("EmptyTOML", new String(d.getAnalyzedToml()));
         }
 
         String[] args = argsCaptor.getValue();
         assertNotNull(args);
-        //verify 1st & last elements
         assertEquals("/cnb/lifecycle/detector", args[0]);
         assertNotEquals(args[args.length-1], OUTPUT_IMAGE);
 
         List<String> argList = Arrays.asList(args);
-        //verify  generated for a 0.10 run with extensions
         assertTrue(argList.contains("-generated"));
-        //verify no dameon
         assertFalse(argList.contains("-daemon"));
-        //verify log as expected
         assertTrue(argList.contains(LOG_LEVEL));
-        //verify run arg is present
         assertTrue(argList.contains("-run"));
         assertTrue(argList.contains("/cnb/run.toml"));
 
@@ -411,64 +234,12 @@ public class DetectorTest {
 
     @SuppressWarnings("resource")
     @Test
-    void test10WithoutExtensions(@Mock LifecyclePhaseFactory factory, 
-                  @Mock BuilderImage builder, 
-                  @Mock LogConfig logConfig, 
-                  @Mock DockerConfig dockerConfig, 
-                  @Mock DockerClient dockerClient,
-                  @Mock StartContainerCmd startCmd,
-                  @Mock LogContainerCmd logCmd,
-                  @Mock WaitContainerCmd waitCmd,
-                  @Mock WaitContainerResultCallback waitResult,
-                  @Mock Logger logger
-                  ) {
-        
-        String  PLATFORM_LEVEL="0.10";
-        String  LOG_LEVEL="debug";
-        String  CONTAINER_ID="999";
-        int     CONTAINER_RC=99;
-        int     USER_ID=77;
-        int     GROUP_ID=88;
-        String  OUTPUT_IMAGE="stiletto";
-        boolean USE_DAEMON=false;
-        boolean HAS_EXTENSIONS=false; 
-
-        lenient().when(dockerConfig.getUseDaemon()).thenReturn(USE_DAEMON);
-        lenient().when(dockerConfig.getDockerClient()).thenReturn(dockerClient);        
-        lenient().when(factory.getDockerConfig()).thenReturn(dockerConfig);
-
-        lenient().doNothing().when(startCmd).exec();
-        lenient().when(dockerClient.startContainerCmd(any())).thenReturn(startCmd);
-
-        lenient().when(logCmd.withFollowStream(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withStdOut(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withStdErr(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withTimestamps(any())).thenReturn(logCmd);
-        lenient().when(logCmd.exec(any())).thenReturn(null);
-        lenient().when(dockerClient.logContainerCmd(any())).thenReturn(logCmd);
-
-        lenient().when(waitCmd.exec(any())).thenReturn(waitResult);
-        lenient().when(waitResult.awaitStatusCode()).thenReturn(CONTAINER_RC);
-        lenient().when(dockerClient.waitContainerCmd(any())).thenReturn(waitCmd);
-
-        lenient().when(logConfig.getLogLevel()).thenReturn(LOG_LEVEL);
-        lenient().when(factory.getLogConfig()).thenReturn(logConfig);
-
-        lenient().when(builder.getUserId()).thenReturn(USER_ID);
-        lenient().when(builder.getGroupId()).thenReturn(GROUP_ID);
-        lenient().when(builder.getRunImages(any())).thenReturn(Stream.of(new ImageReference("runimage1"), new ImageReference("runimage2")).collect(Collectors.toList()).toArray(new ImageReference[]{}));
-        lenient().when(builder.hasExtensions()).thenReturn(HAS_EXTENSIONS);
-        lenient().when(factory.getBuilderImage()).thenReturn(builder);
-
-        lenient().when(factory.getPlatformLevel()).thenReturn(new Version(PLATFORM_LEVEL));
-
-        lenient().when(factory.getContainerForPhase(argsCaptor.capture(), any())).thenReturn(CONTAINER_ID);
-
-        lenient().when(factory.getOutputImage()).thenReturn(new ImageReference(OUTPUT_IMAGE));
+    void test10WithoutExtensions() {
+        lenient().when(builder.hasExtensions()).thenReturn(false);
+        lenient().when(factory.getPlatformLevel()).thenReturn(new Version("0.10"));
 
         try (MockedStatic<? extends ContainerUtils> containerUtils = mockStatic(ContainerUtils.class)) {
             Detector d = new Detector(factory);
-
             containerUtils.when(() -> ContainerUtils.getFileFromContainer(eq(dockerClient), any(), any())).thenReturn("EmptyTOML".getBytes());
 
             ContainerStatus cs = d.runPhase(logger, true);
@@ -476,22 +247,17 @@ public class DetectorTest {
             assertNotNull(cs);
             assertEquals(CONTAINER_ID, cs.getContainerId());
             assertEquals(CONTAINER_RC, cs.getRc());
-
             assertEquals("EmptyTOML", new String(d.getAnalyzedToml()));
         }
 
         String[] args = argsCaptor.getValue();
         assertNotNull(args);
-        //verify 1st & last elements
         assertEquals("/cnb/lifecycle/detector", args[0]);
         assertNotEquals(args[args.length-1], OUTPUT_IMAGE);
 
         List<String> argList = Arrays.asList(args);
-        //verify  generated for a 0.10 run without extensions
         assertFalse(argList.contains("-generated"));
-        //verify no dameon
         assertFalse(argList.contains("-daemon"));
-        //verify log as expected
         assertTrue(argList.contains(LOG_LEVEL));
 
         verify(logCmd).withTimestamps(true);
@@ -501,64 +267,11 @@ public class DetectorTest {
 
     @SuppressWarnings("resource")
     @Test
-    void testDisableTimestamps(@Mock LifecyclePhaseFactory factory, 
-                  @Mock BuilderImage builder, 
-                  @Mock LogConfig logConfig, 
-                  @Mock DockerConfig dockerConfig, 
-                  @Mock DockerClient dockerClient,
-                  @Mock StartContainerCmd startCmd,
-                  @Mock LogContainerCmd logCmd,
-                  @Mock WaitContainerCmd waitCmd,
-                  @Mock WaitContainerResultCallback waitResult,
-                  @Mock Logger logger
-                  ) {
-        
-        String  PLATFORM_LEVEL="0.10";
-        String  LOG_LEVEL="debug";
-        String  CONTAINER_ID="999";
-        int     CONTAINER_RC=99;
-        int     USER_ID=77;
-        int     GROUP_ID=88;
-        String  OUTPUT_IMAGE="stiletto";
-        boolean USE_DAEMON=false;
-        boolean HAS_EXTENSIONS=true; 
-
-        lenient().when(dockerConfig.getUseDaemon()).thenReturn(USE_DAEMON);
-        lenient().when(dockerConfig.getDockerClient()).thenReturn(dockerClient);        
-        lenient().when(factory.getDockerConfig()).thenReturn(dockerConfig);
-
-        lenient().doNothing().when(startCmd).exec();
-        lenient().when(dockerClient.startContainerCmd(any())).thenReturn(startCmd);
-
-        lenient().when(logCmd.withFollowStream(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withStdOut(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withStdErr(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withTimestamps(any())).thenReturn(logCmd);
-        lenient().when(logCmd.exec(any())).thenReturn(null);
-        lenient().when(dockerClient.logContainerCmd(any())).thenReturn(logCmd);
-
-        lenient().when(waitCmd.exec(any())).thenReturn(waitResult);
-        lenient().when(waitResult.awaitStatusCode()).thenReturn(CONTAINER_RC);
-        lenient().when(dockerClient.waitContainerCmd(any())).thenReturn(waitCmd);
-
-        lenient().when(logConfig.getLogLevel()).thenReturn(LOG_LEVEL);
-        lenient().when(factory.getLogConfig()).thenReturn(logConfig);
-
-        lenient().when(builder.getUserId()).thenReturn(USER_ID);
-        lenient().when(builder.getGroupId()).thenReturn(GROUP_ID);
-        lenient().when(builder.getRunImages(any())).thenReturn(Stream.of(new ImageReference("runimage1"), new ImageReference("runimage2")).collect(Collectors.toList()).toArray(new ImageReference[]{}));
-        lenient().when(builder.hasExtensions()).thenReturn(HAS_EXTENSIONS);
-        lenient().when(factory.getBuilderImage()).thenReturn(builder);
-
-        lenient().when(factory.getPlatformLevel()).thenReturn(new Version(PLATFORM_LEVEL));
-
-        lenient().when(factory.getContainerForPhase(argsCaptor.capture(), any())).thenReturn(CONTAINER_ID);
-
-        lenient().when(factory.getOutputImage()).thenReturn(new ImageReference(OUTPUT_IMAGE));
+    void testDisableTimestamps() {
+        lenient().when(factory.getPlatformLevel()).thenReturn(new Version("0.10"));
 
         try (MockedStatic<? extends ContainerUtils> containerUtils = mockStatic(ContainerUtils.class)) {
             Detector d = new Detector(factory);
-
             containerUtils.when(() -> ContainerUtils.getFileFromContainer(eq(dockerClient), any(), any())).thenReturn("EmptyTOML".getBytes());
 
             ContainerStatus cs = d.runPhase(logger, false);
@@ -566,22 +279,17 @@ public class DetectorTest {
             assertNotNull(cs);
             assertEquals(CONTAINER_ID, cs.getContainerId());
             assertEquals(CONTAINER_RC, cs.getRc());
-
             assertEquals("EmptyTOML", new String(d.getAnalyzedToml()));
         }
 
         String[] args = argsCaptor.getValue();
         assertNotNull(args);
-        //verify 1st & last elements
         assertEquals("/cnb/lifecycle/detector", args[0]);
         assertNotEquals(args[args.length-1], OUTPUT_IMAGE);
 
         List<String> argList = Arrays.asList(args);
-        //verify  generated for a 0.10 run with extensions
         assertTrue(argList.contains("-generated"));
-        //verify dameon
         assertFalse(argList.contains("-daemon"));
-        //verify log as expected
         assertTrue(argList.contains(LOG_LEVEL));
 
         verify(logCmd).withTimestamps(false);

--- a/client/src/test/java/dev/snowdrop/buildpack/lifecycle/phases/ExporterTest.java
+++ b/client/src/test/java/dev/snowdrop/buildpack/lifecycle/phases/ExporterTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -39,31 +40,30 @@ import dev.snowdrop.buildpack.lifecycle.Version;
 @ExtendWith(MockitoExtension.class)
 public class ExporterTest {
 
+    private static final String LOG_LEVEL = "debug";
+    private static final String CONTAINER_ID = "999";
+    private static final int CONTAINER_RC = 99;
+    private static final int USER_ID = 77;
+    private static final int GROUP_ID = 88;
+    private static final String OUTPUT_IMAGE = "stiletto";
+    private static final boolean USE_DAEMON = false;
+
     @Captor
     ArgumentCaptor<String[]> argsCaptor;
 
-    @Test
-    void testPre7(@Mock LifecyclePhaseFactory factory, 
-                  @Mock BuilderImage builder, 
-                  @Mock LogConfig logConfig, 
-                  @Mock DockerConfig dockerConfig, 
-                  @Mock DockerClient dockerClient,
-                  @Mock StartContainerCmd startCmd,
-                  @Mock LogContainerCmd logCmd,
-                  @Mock WaitContainerCmd waitCmd,
-                  @Mock WaitContainerResultCallback waitResult,
-                  @Mock Logger logger
-                  ) {
-        
-        String  PLATFORM_LEVEL="0.6";
-        String  LOG_LEVEL="debug";
-        String  CONTAINER_ID="999";
-        int     CONTAINER_RC=99;
-        int     USER_ID=77;
-        int     GROUP_ID=88;
-        String  OUTPUT_IMAGE="stiletto";
-        boolean USE_DAEMON=false;
+    @Mock LifecyclePhaseFactory factory;
+    @Mock BuilderImage builder;
+    @Mock LogConfig logConfig;
+    @Mock DockerConfig dockerConfig;
+    @Mock DockerClient dockerClient;
+    @Mock StartContainerCmd startCmd;
+    @Mock LogContainerCmd logCmd;
+    @Mock WaitContainerCmd waitCmd;
+    @Mock WaitContainerResultCallback waitResult;
+    @Mock Logger logger;
 
+    @BeforeEach
+    void setUp() {
         lenient().when(dockerConfig.getUseDaemon()).thenReturn(USE_DAEMON);
         lenient().when(dockerConfig.getDockerClient()).thenReturn(dockerClient);        
         lenient().when(factory.getDockerConfig()).thenReturn(dockerConfig);
@@ -90,11 +90,14 @@ public class ExporterTest {
         lenient().when(builder.getRunImages(any())).thenReturn(Stream.of(new ImageReference("runimage1"), new ImageReference("runimage2")).collect(Collectors.toList()).toArray(new ImageReference[]{}));
         lenient().when(factory.getBuilderImage()).thenReturn(builder);
 
-        lenient().when(factory.getPlatformLevel()).thenReturn(new Version(PLATFORM_LEVEL));
-
         lenient().when(factory.getContainerForPhase(argsCaptor.capture(), any())).thenReturn(CONTAINER_ID);
 
         lenient().when(factory.getOutputImage()).thenReturn(new ImageReference(OUTPUT_IMAGE));
+    }
+
+    @Test
+    void testPre7() {
+        lenient().when(factory.getPlatformLevel()).thenReturn(new Version("0.6"));
 
         Exporter e = new Exporter(factory, false);
 
@@ -106,17 +109,13 @@ public class ExporterTest {
 
         String[] args = argsCaptor.getValue();
         assertNotNull(args);
-        //verify 1st & last elements
         assertEquals("/cnb/lifecycle/exporter", args[0]);
         assertEquals(new ImageReference(OUTPUT_IMAGE).getReferenceWithLatest(), args[args.length-1]);
 
         List<String> argList = Arrays.asList(args);
-        //verify run-image is used for a pre7 run
         assertTrue(argList.contains("-run-image"));
         assertFalse(argList.contains("-run"));
-        //verify no dameon
         assertFalse(argList.contains("-daemon"));
-        //verify log as expected
         assertTrue(argList.contains(LOG_LEVEL));
 
         verify(logCmd).withTimestamps(true);
@@ -125,58 +124,8 @@ public class ExporterTest {
     }
 
     @Test
-    void test7Onwards(@Mock LifecyclePhaseFactory factory, 
-                  @Mock BuilderImage builder, 
-                  @Mock LogConfig logConfig, 
-                  @Mock DockerConfig dockerConfig, 
-                  @Mock DockerClient dockerClient,
-                  @Mock StartContainerCmd startCmd,
-                  @Mock LogContainerCmd logCmd,
-                  @Mock WaitContainerCmd waitCmd,
-                  @Mock WaitContainerResultCallback waitResult,
-                  @Mock Logger logger
-                  ) {
-        
-        String  PLATFORM_LEVEL="0.7";
-        String  LOG_LEVEL="debug";
-        String  CONTAINER_ID="999";
-        int     CONTAINER_RC=99;
-        int     USER_ID=77;
-        int     GROUP_ID=88;
-        String  OUTPUT_IMAGE="stiletto";
-        boolean USE_DAEMON=false;
-
-        lenient().when(dockerConfig.getUseDaemon()).thenReturn(USE_DAEMON);
-        lenient().when(dockerConfig.getDockerClient()).thenReturn(dockerClient);        
-        lenient().when(factory.getDockerConfig()).thenReturn(dockerConfig);
-
-        lenient().doNothing().when(startCmd).exec();
-        lenient().when(dockerClient.startContainerCmd(any())).thenReturn(startCmd);
-
-        lenient().when(logCmd.withFollowStream(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withStdOut(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withStdErr(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withTimestamps(any())).thenReturn(logCmd);
-        lenient().when(logCmd.exec(any())).thenReturn(null);
-        lenient().when(dockerClient.logContainerCmd(any())).thenReturn(logCmd);
-
-        lenient().when(waitCmd.exec(any())).thenReturn(waitResult);
-        lenient().when(waitResult.awaitStatusCode()).thenReturn(CONTAINER_RC);
-        lenient().when(dockerClient.waitContainerCmd(any())).thenReturn(waitCmd);
-
-        lenient().when(logConfig.getLogLevel()).thenReturn(LOG_LEVEL);
-        lenient().when(factory.getLogConfig()).thenReturn(logConfig);
-
-        lenient().when(builder.getUserId()).thenReturn(USER_ID);
-        lenient().when(builder.getGroupId()).thenReturn(GROUP_ID);
-        lenient().when(builder.getRunImages(any())).thenReturn(Stream.of(new ImageReference("runimage1"), new ImageReference("runimage2")).collect(Collectors.toList()).toArray(new ImageReference[]{}));
-        lenient().when(factory.getBuilderImage()).thenReturn(builder);
-
-        lenient().when(factory.getPlatformLevel()).thenReturn(new Version(PLATFORM_LEVEL));
-
-        lenient().when(factory.getContainerForPhase(argsCaptor.capture(), any())).thenReturn(CONTAINER_ID);
-
-        lenient().when(factory.getOutputImage()).thenReturn(new ImageReference(OUTPUT_IMAGE));
+    void test7Onwards() {
+        lenient().when(factory.getPlatformLevel()).thenReturn(new Version("0.7"));
 
         Exporter e = new Exporter(factory, false);
 
@@ -188,17 +137,13 @@ public class ExporterTest {
 
         String[] args = argsCaptor.getValue();
         assertNotNull(args);
-        //verify 1st & last elements
         assertEquals("/cnb/lifecycle/exporter", args[0]);
         assertEquals(new ImageReference(OUTPUT_IMAGE).getReferenceWithLatest(), args[args.length-1]);
 
         List<String> argList = Arrays.asList(args);
-        //verify run-image is not used for a 7 onwards run
         assertFalse(argList.contains("-run-image"));
         assertFalse(argList.contains("-run"));
-        //verify no dameon
         assertFalse(argList.contains("-daemon"));
-        //verify log as expected
         assertTrue(argList.contains(LOG_LEVEL));
 
         verify(logCmd).withTimestamps(true);
@@ -207,58 +152,8 @@ public class ExporterTest {
     }    
 
     @Test
-    void test12OnwardsNoRunExt(@Mock LifecyclePhaseFactory factory, 
-                  @Mock BuilderImage builder, 
-                  @Mock LogConfig logConfig, 
-                  @Mock DockerConfig dockerConfig, 
-                  @Mock DockerClient dockerClient,
-                  @Mock StartContainerCmd startCmd,
-                  @Mock LogContainerCmd logCmd,
-                  @Mock WaitContainerCmd waitCmd,
-                  @Mock WaitContainerResultCallback waitResult,
-                  @Mock Logger logger
-                  ) {
-        
-        String  PLATFORM_LEVEL="0.12";
-        String  LOG_LEVEL="debug";
-        String  CONTAINER_ID="999";
-        int     CONTAINER_RC=99;
-        int     USER_ID=77;
-        int     GROUP_ID=88;
-        String  OUTPUT_IMAGE="stiletto";
-        boolean USE_DAEMON=false;
-
-        lenient().when(dockerConfig.getUseDaemon()).thenReturn(USE_DAEMON);
-        lenient().when(dockerConfig.getDockerClient()).thenReturn(dockerClient);        
-        lenient().when(factory.getDockerConfig()).thenReturn(dockerConfig);
-
-        lenient().doNothing().when(startCmd).exec();
-        lenient().when(dockerClient.startContainerCmd(any())).thenReturn(startCmd);
-
-        lenient().when(logCmd.withFollowStream(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withStdOut(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withStdErr(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withTimestamps(any())).thenReturn(logCmd);
-        lenient().when(logCmd.exec(any())).thenReturn(null);
-        lenient().when(dockerClient.logContainerCmd(any())).thenReturn(logCmd);
-
-        lenient().when(waitCmd.exec(any())).thenReturn(waitResult);
-        lenient().when(waitResult.awaitStatusCode()).thenReturn(CONTAINER_RC);
-        lenient().when(dockerClient.waitContainerCmd(any())).thenReturn(waitCmd);
-
-        lenient().when(logConfig.getLogLevel()).thenReturn(LOG_LEVEL);
-        lenient().when(factory.getLogConfig()).thenReturn(logConfig);
-
-        lenient().when(builder.getUserId()).thenReturn(USER_ID);
-        lenient().when(builder.getGroupId()).thenReturn(GROUP_ID);
-        lenient().when(builder.getRunImages(any())).thenReturn(Stream.of(new ImageReference("runimage1"), new ImageReference("runimage2")).collect(Collectors.toList()).toArray(new ImageReference[]{}));
-        lenient().when(factory.getBuilderImage()).thenReturn(builder);
-
-        lenient().when(factory.getPlatformLevel()).thenReturn(new Version(PLATFORM_LEVEL));
-
-        lenient().when(factory.getContainerForPhase(argsCaptor.capture(), any())).thenReturn(CONTAINER_ID);
-
-        lenient().when(factory.getOutputImage()).thenReturn(new ImageReference(OUTPUT_IMAGE));
+    void test12OnwardsNoRunExt() {
+        lenient().when(factory.getPlatformLevel()).thenReturn(new Version("0.12"));
 
         Exporter e = new Exporter(factory, false);
 
@@ -270,17 +165,13 @@ public class ExporterTest {
 
         String[] args = argsCaptor.getValue();
         assertNotNull(args);
-        //verify 1st & last elements
         assertEquals("/cnb/lifecycle/exporter", args[0]);
         assertEquals(new ImageReference(OUTPUT_IMAGE).getReferenceWithLatest(), args[args.length-1]);
 
         List<String> argList = Arrays.asList(args);
-        //verify run is not used for a 12 run with no run extns
         assertFalse(argList.contains("-run-image"));
         assertFalse(argList.contains("-run"));
-        //verify no dameon
         assertFalse(argList.contains("-daemon"));
-        //verify log as expected
         assertTrue(argList.contains(LOG_LEVEL));
 
         verify(logCmd).withTimestamps(true);
@@ -289,58 +180,8 @@ public class ExporterTest {
     }   
 
     @Test
-    void test12OnwardsRunExt(@Mock LifecyclePhaseFactory factory, 
-                  @Mock BuilderImage builder, 
-                  @Mock LogConfig logConfig, 
-                  @Mock DockerConfig dockerConfig, 
-                  @Mock DockerClient dockerClient,
-                  @Mock StartContainerCmd startCmd,
-                  @Mock LogContainerCmd logCmd,
-                  @Mock WaitContainerCmd waitCmd,
-                  @Mock WaitContainerResultCallback waitResult,
-                  @Mock Logger logger
-                  ) {
-        
-        String  PLATFORM_LEVEL="0.12";
-        String  LOG_LEVEL="debug";
-        String  CONTAINER_ID="999";
-        int     CONTAINER_RC=99;
-        int     USER_ID=77;
-        int     GROUP_ID=88;
-        String  OUTPUT_IMAGE="stiletto";
-        boolean USE_DAEMON=false;
-
-        lenient().when(dockerConfig.getUseDaemon()).thenReturn(USE_DAEMON);
-        lenient().when(dockerConfig.getDockerClient()).thenReturn(dockerClient);        
-        lenient().when(factory.getDockerConfig()).thenReturn(dockerConfig);
-
-        lenient().doNothing().when(startCmd).exec();
-        lenient().when(dockerClient.startContainerCmd(any())).thenReturn(startCmd);
-
-        lenient().when(logCmd.withFollowStream(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withStdOut(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withStdErr(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withTimestamps(any())).thenReturn(logCmd);
-        lenient().when(logCmd.exec(any())).thenReturn(null);
-        lenient().when(dockerClient.logContainerCmd(any())).thenReturn(logCmd);
-
-        lenient().when(waitCmd.exec(any())).thenReturn(waitResult);
-        lenient().when(waitResult.awaitStatusCode()).thenReturn(CONTAINER_RC);
-        lenient().when(dockerClient.waitContainerCmd(any())).thenReturn(waitCmd);
-
-        lenient().when(logConfig.getLogLevel()).thenReturn(LOG_LEVEL);
-        lenient().when(factory.getLogConfig()).thenReturn(logConfig);
-
-        lenient().when(builder.getUserId()).thenReturn(USER_ID);
-        lenient().when(builder.getGroupId()).thenReturn(GROUP_ID);
-        lenient().when(builder.getRunImages(any())).thenReturn(Stream.of(new ImageReference("runimage1"), new ImageReference("runimage2")).collect(Collectors.toList()).toArray(new ImageReference[]{}));
-        lenient().when(factory.getBuilderImage()).thenReturn(builder);
-
-        lenient().when(factory.getPlatformLevel()).thenReturn(new Version(PLATFORM_LEVEL));
-
-        lenient().when(factory.getContainerForPhase(argsCaptor.capture(), any())).thenReturn(CONTAINER_ID);
-
-        lenient().when(factory.getOutputImage()).thenReturn(new ImageReference(OUTPUT_IMAGE));
+    void test12OnwardsRunExt() {
+        lenient().when(factory.getPlatformLevel()).thenReturn(new Version("0.12"));
 
         Exporter e = new Exporter(factory, true);
 
@@ -352,17 +193,13 @@ public class ExporterTest {
 
         String[] args = argsCaptor.getValue();
         assertNotNull(args);
-        //verify 1st & last elements
         assertEquals("/cnb/lifecycle/exporter", args[0]);
         assertEquals(new ImageReference(OUTPUT_IMAGE).getReferenceWithLatest(), args[args.length-1]);
 
         List<String> argList = Arrays.asList(args);
-        //verify run is not used for a 12 run with no run extns
         assertFalse(argList.contains("-run-image"));
         assertTrue(argList.contains("-run"));
-        //verify no dameon
         assertFalse(argList.contains("-daemon"));
-        //verify log as expected
         assertTrue(argList.contains(LOG_LEVEL));
 
         verify(logCmd).withTimestamps(true);
@@ -371,60 +208,8 @@ public class ExporterTest {
     }       
 
     @Test
-    void testDisableTimestamps(@Mock LifecyclePhaseFactory factory, 
-                  @Mock BuilderImage builder, 
-                  @Mock LogConfig logConfig, 
-                  @Mock DockerConfig dockerConfig, 
-                  @Mock DockerClient dockerClient,
-                  @Mock StartContainerCmd startCmd,
-                  @Mock LogContainerCmd logCmd,
-                  @Mock WaitContainerCmd waitCmd,
-                  @Mock WaitContainerResultCallback waitResult,
-                  @Mock Logger logger
-                  ) 
-    {
-        
-        String  PLATFORM_LEVEL="0.9";
-        String  LOG_LEVEL="debug";
-        String  CONTAINER_ID="999";
-        int     CONTAINER_RC=99;
-        int     USER_ID=77;
-        int     GROUP_ID=88;
-        String  OUTPUT_IMAGE="stiletto";
-        boolean USE_DAEMON=false;
-
-        lenient().when(dockerConfig.getUseDaemon()).thenReturn(USE_DAEMON);
-        lenient().when(dockerConfig.getDockerClient()).thenReturn(dockerClient);        
-        lenient().when(factory.getDockerConfig()).thenReturn(dockerConfig);
-
-        lenient().doNothing().when(startCmd).exec();
-        lenient().when(dockerClient.startContainerCmd(any())).thenReturn(startCmd);
-
-        lenient().when(logCmd.withFollowStream(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withStdOut(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withStdErr(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withTimestamps(any())).thenReturn(logCmd);
-        lenient().when(logCmd.exec(any())).thenReturn(null);
-        lenient().when(dockerClient.logContainerCmd(any())).thenReturn(logCmd);
-
-        lenient().when(waitCmd.exec(any())).thenReturn(waitResult);
-        lenient().when(waitResult.awaitStatusCode()).thenReturn(CONTAINER_RC);
-        lenient().when(dockerClient.waitContainerCmd(any())).thenReturn(waitCmd);
-
-        lenient().when(logConfig.getLogLevel()).thenReturn(LOG_LEVEL);
-        lenient().when(factory.getLogConfig()).thenReturn(logConfig);
-
-        lenient().when(builder.getUserId()).thenReturn(USER_ID);
-        lenient().when(builder.getGroupId()).thenReturn(GROUP_ID);
-        lenient().when(builder.getRunImages(any())).thenReturn(Stream.of(new ImageReference("runimage1"), new ImageReference("runimage2")).collect(Collectors.toList()).toArray(new ImageReference[]{}));
-        lenient().when(factory.getBuilderImage()).thenReturn(builder);
-
-        lenient().when(factory.getPlatformLevel()).thenReturn(new Version(PLATFORM_LEVEL));
-
-        lenient().when(factory.getContainerForPhase(argsCaptor.capture(), any())).thenReturn(CONTAINER_ID);
-
-        lenient().when(factory.getOutputImage()).thenReturn(new ImageReference(OUTPUT_IMAGE));
-
+    void testDisableTimestamps() {
+        lenient().when(factory.getPlatformLevel()).thenReturn(new Version("0.9"));
 
         Exporter e = new Exporter(factory, false);
 
@@ -436,14 +221,11 @@ public class ExporterTest {
 
         String[] args = argsCaptor.getValue();
         assertNotNull(args);
-        //verify 1st & last elements
         assertEquals("/cnb/lifecycle/exporter", args[0]);
         assertEquals(new ImageReference(OUTPUT_IMAGE).getReferenceWithLatest(), args[args.length-1]);
 
         List<String> argList = Arrays.asList(args);
-        //verify daemon
         assertFalse(argList.contains("-daemon"));
-        //verify log as expected
         assertTrue(argList.contains(LOG_LEVEL));
 
         verify(logCmd).withTimestamps(false);
@@ -452,59 +234,9 @@ public class ExporterTest {
     }  
 
     @Test
-    void testWithDaemon(@Mock LifecyclePhaseFactory factory, 
-                  @Mock BuilderImage builder, 
-                  @Mock LogConfig logConfig, 
-                  @Mock DockerConfig dockerConfig, 
-                  @Mock DockerClient dockerClient,
-                  @Mock StartContainerCmd startCmd,
-                  @Mock LogContainerCmd logCmd,
-                  @Mock WaitContainerCmd waitCmd,
-                  @Mock WaitContainerResultCallback waitResult,
-                  @Mock Logger logger
-                  ) 
-    {
-        
-        String  PLATFORM_LEVEL="0.9";
-        String  LOG_LEVEL="debug";
-        String  CONTAINER_ID="999";
-        int     CONTAINER_RC=99;
-        int     USER_ID=77;
-        int     GROUP_ID=88;
-        String  OUTPUT_IMAGE="stiletto";
-        boolean USE_DAEMON=true;
-
-        lenient().when(dockerConfig.getUseDaemon()).thenReturn(USE_DAEMON);
-        lenient().when(dockerConfig.getDockerClient()).thenReturn(dockerClient);        
-        lenient().when(factory.getDockerConfig()).thenReturn(dockerConfig);
-
-        lenient().doNothing().when(startCmd).exec();
-        lenient().when(dockerClient.startContainerCmd(any())).thenReturn(startCmd);
-
-        lenient().when(logCmd.withFollowStream(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withStdOut(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withStdErr(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withTimestamps(any())).thenReturn(logCmd);
-        lenient().when(logCmd.exec(any())).thenReturn(null);
-        lenient().when(dockerClient.logContainerCmd(any())).thenReturn(logCmd);
-
-        lenient().when(waitCmd.exec(any())).thenReturn(waitResult);
-        lenient().when(waitResult.awaitStatusCode()).thenReturn(CONTAINER_RC);
-        lenient().when(dockerClient.waitContainerCmd(any())).thenReturn(waitCmd);
-
-        lenient().when(logConfig.getLogLevel()).thenReturn(LOG_LEVEL);
-        lenient().when(factory.getLogConfig()).thenReturn(logConfig);
-
-        lenient().when(builder.getUserId()).thenReturn(USER_ID);
-        lenient().when(builder.getGroupId()).thenReturn(GROUP_ID);
-        lenient().when(builder.getRunImages(any())).thenReturn(Stream.of(new ImageReference("runimage1"), new ImageReference("runimage2")).collect(Collectors.toList()).toArray(new ImageReference[]{}));
-        lenient().when(factory.getBuilderImage()).thenReturn(builder);
-
-        lenient().when(factory.getPlatformLevel()).thenReturn(new Version(PLATFORM_LEVEL));
-
-        lenient().when(factory.getContainerForPhase(argsCaptor.capture(), any())).thenReturn(CONTAINER_ID);
-
-        lenient().when(factory.getOutputImage()).thenReturn(new ImageReference(OUTPUT_IMAGE));
+    void testWithDaemon() {
+        lenient().when(dockerConfig.getUseDaemon()).thenReturn(true);
+        lenient().when(factory.getPlatformLevel()).thenReturn(new Version("0.9"));
 
         Exporter e = new Exporter(factory, false);
 
@@ -516,19 +248,15 @@ public class ExporterTest {
 
         String[] args = argsCaptor.getValue();
         assertNotNull(args);
-        //verify 1st & last elements
         assertEquals("/cnb/lifecycle/exporter", args[0]);
         assertEquals(new ImageReference(OUTPUT_IMAGE).getReferenceWithLatest(), args[args.length-1]);
 
         List<String> argList = Arrays.asList(args);
-        //verify dameon
         assertTrue(argList.contains("-daemon"));
-        //verify log as expected
         assertTrue(argList.contains(LOG_LEVEL));
 
         verify(logCmd).withTimestamps(true);
         verify(dockerClient).logContainerCmd(CONTAINER_ID);
         verify(factory).getContainerForPhase(any(String[].class), eq(0));
     }     
-
 }

--- a/client/src/test/java/dev/snowdrop/buildpack/lifecycle/phases/ExtenderTest.java
+++ b/client/src/test/java/dev/snowdrop/buildpack/lifecycle/phases/ExtenderTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -40,31 +41,30 @@ import dev.snowdrop.buildpack.lifecycle.Version;
 @ExtendWith(MockitoExtension.class)
 public class ExtenderTest {
 
+    private static final String LOG_LEVEL = "debug";
+    private static final String CONTAINER_ID = "999";
+    private static final int CONTAINER_RC = 99;
+    private static final int USER_ID = 77;
+    private static final int GROUP_ID = 88;
+    private static final String OUTPUT_IMAGE = "stiletto";
+    private static final boolean USE_DAEMON = false;
+
     @Captor
     ArgumentCaptor<String[]> argsCaptor;
 
-    @Test
-    void testPre12(@Mock LifecyclePhaseFactory factory, 
-                  @Mock BuilderImage builder, 
-                  @Mock LogConfig logConfig, 
-                  @Mock DockerConfig dockerConfig, 
-                  @Mock DockerClient dockerClient,
-                  @Mock StartContainerCmd startCmd,
-                  @Mock LogContainerCmd logCmd,
-                  @Mock WaitContainerCmd waitCmd,
-                  @Mock WaitContainerResultCallback waitResult,
-                  @Mock Logger logger
-                  ) {
-        
-        String  PLATFORM_LEVEL="0.10";
-        String  LOG_LEVEL="debug";
-        String  CONTAINER_ID="999";
-        int     CONTAINER_RC=99;
-        int     USER_ID=77;
-        int     GROUP_ID=88;
-        String  OUTPUT_IMAGE="stiletto";
-        boolean USE_DAEMON=false;
+    @Mock LifecyclePhaseFactory factory;
+    @Mock BuilderImage builder;
+    @Mock LogConfig logConfig;
+    @Mock DockerConfig dockerConfig;
+    @Mock DockerClient dockerClient;
+    @Mock StartContainerCmd startCmd;
+    @Mock LogContainerCmd logCmd;
+    @Mock WaitContainerCmd waitCmd;
+    @Mock WaitContainerResultCallback waitResult;
+    @Mock Logger logger;
 
+    @BeforeEach
+    void setUp() {
         lenient().when(dockerConfig.getUseDaemon()).thenReturn(USE_DAEMON);
         lenient().when(dockerConfig.getDockerClient()).thenReturn(dockerClient);        
         lenient().when(factory.getDockerConfig()).thenReturn(dockerConfig);
@@ -91,11 +91,14 @@ public class ExtenderTest {
         lenient().when(builder.getRunImages(any())).thenReturn(Stream.of(new ImageReference("runimage1"), new ImageReference("runimage2")).collect(Collectors.toList()).toArray(new ImageReference[]{}));        
         lenient().when(factory.getBuilderImage()).thenReturn(builder);
 
-        lenient().when(factory.getPlatformLevel()).thenReturn(new Version(PLATFORM_LEVEL));
-
         lenient().when(factory.getContainerForPhase(argsCaptor.capture(), any())).thenReturn(CONTAINER_ID);
 
         lenient().when(factory.getOutputImage()).thenReturn(new ImageReference(OUTPUT_IMAGE));
+    }
+
+    @Test
+    void testPre12() {
+        lenient().when(factory.getPlatformLevel()).thenReturn(new Version("0.10"));
 
         Extender e = new Extender(factory, null);
 
@@ -107,74 +110,21 @@ public class ExtenderTest {
 
         String[] args = argsCaptor.getValue();
         assertNotNull(args);
-        //verify 1st & last elements
         assertEquals("/cnb/lifecycle/extender", args[0]);
         assertNotEquals(args[args.length-1], OUTPUT_IMAGE);
 
         List<String> argList = Arrays.asList(args);
-        //verify kind not present in pre12
         assertFalse(argList.contains("-kind"));
-        //verify log as expected
         assertTrue(argList.contains(LOG_LEVEL));
 
         verify(logCmd).withTimestamps(true);
         verify(dockerClient).logContainerCmd(CONTAINER_ID);
-        verify(factory).getContainerForPhase(any(String[].class), eq(0)); //extender always runs as root
+        verify(factory).getContainerForPhase(any(String[].class), eq(0));
     }
     
     @Test
-    void test12OnwardsBuild(@Mock LifecyclePhaseFactory factory, 
-                  @Mock BuilderImage builder, 
-                  @Mock LogConfig logConfig, 
-                  @Mock DockerConfig dockerConfig, 
-                  @Mock DockerClient dockerClient,
-                  @Mock StartContainerCmd startCmd,
-                  @Mock LogContainerCmd logCmd,
-                  @Mock WaitContainerCmd waitCmd,
-                  @Mock WaitContainerResultCallback waitResult,
-                  @Mock Logger logger
-                  ) {
-        
-        String  PLATFORM_LEVEL="0.12";
-        String  LOG_LEVEL="debug";
-        String  CONTAINER_ID="999";
-        int     CONTAINER_RC=99;
-        int     USER_ID=77;
-        int     GROUP_ID=88;
-        String  OUTPUT_IMAGE="stiletto";
-        boolean USE_DAEMON=false;
-
-        lenient().when(dockerConfig.getUseDaemon()).thenReturn(USE_DAEMON);
-        lenient().when(dockerConfig.getDockerClient()).thenReturn(dockerClient);        
-        lenient().when(factory.getDockerConfig()).thenReturn(dockerConfig);
-
-        lenient().doNothing().when(startCmd).exec();
-        lenient().when(dockerClient.startContainerCmd(any())).thenReturn(startCmd);
-
-        lenient().when(logCmd.withFollowStream(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withStdOut(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withStdErr(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withTimestamps(any())).thenReturn(logCmd);
-        lenient().when(logCmd.exec(any())).thenReturn(null);
-        lenient().when(dockerClient.logContainerCmd(any())).thenReturn(logCmd);
-
-        lenient().when(waitCmd.exec(any())).thenReturn(waitResult);
-        lenient().when(waitResult.awaitStatusCode()).thenReturn(CONTAINER_RC);
-        lenient().when(dockerClient.waitContainerCmd(any())).thenReturn(waitCmd);
-
-        lenient().when(logConfig.getLogLevel()).thenReturn(LOG_LEVEL);
-        lenient().when(factory.getLogConfig()).thenReturn(logConfig);
-
-        lenient().when(builder.getUserId()).thenReturn(USER_ID);
-        lenient().when(builder.getGroupId()).thenReturn(GROUP_ID);
-        lenient().when(builder.getRunImages(any())).thenReturn(Stream.of(new ImageReference("runimage1"), new ImageReference("runimage2")).collect(Collectors.toList()).toArray(new ImageReference[]{}));
-        lenient().when(factory.getBuilderImage()).thenReturn(builder);
-
-        lenient().when(factory.getPlatformLevel()).thenReturn(new Version(PLATFORM_LEVEL));
-
-        lenient().when(factory.getContainerForPhase(argsCaptor.capture(), any())).thenReturn(CONTAINER_ID);
-
-        lenient().when(factory.getOutputImage()).thenReturn(new ImageReference(OUTPUT_IMAGE));
+    void test12OnwardsBuild() {
+        lenient().when(factory.getPlatformLevel()).thenReturn(new Version("0.12"));
 
         Extender e = new Extender(factory, "build");
 
@@ -186,75 +136,22 @@ public class ExtenderTest {
 
         String[] args = argsCaptor.getValue();
         assertNotNull(args);
-        //verify 1st & last elements
         assertEquals("/cnb/lifecycle/extender", args[0]);
         assertNotEquals(args[args.length-1], OUTPUT_IMAGE);
 
         List<String> argList = Arrays.asList(args);
-        //verify kind not present in pre12
         assertTrue(argList.contains("-kind"));
         assertEquals("build", argList.get(argList.indexOf("-kind")+1));
-        //verify log as expected
         assertTrue(argList.contains(LOG_LEVEL));
 
         verify(logCmd).withTimestamps(true);
         verify(dockerClient).logContainerCmd(CONTAINER_ID);
-        verify(factory).getContainerForPhase(any(String[].class), eq(0)); //extender always runs as root
+        verify(factory).getContainerForPhase(any(String[].class), eq(0));
     }
 
     @Test
-    void test12OnwardsRun(@Mock LifecyclePhaseFactory factory, 
-                  @Mock BuilderImage builder, 
-                  @Mock LogConfig logConfig, 
-                  @Mock DockerConfig dockerConfig, 
-                  @Mock DockerClient dockerClient,
-                  @Mock StartContainerCmd startCmd,
-                  @Mock LogContainerCmd logCmd,
-                  @Mock WaitContainerCmd waitCmd,
-                  @Mock WaitContainerResultCallback waitResult,
-                  @Mock Logger logger
-                  ) {
-        
-        String  PLATFORM_LEVEL="0.12";
-        String  LOG_LEVEL="debug";
-        String  CONTAINER_ID="999";
-        int     CONTAINER_RC=99;
-        int     USER_ID=77;
-        int     GROUP_ID=88;
-        String  OUTPUT_IMAGE="stiletto";
-        boolean USE_DAEMON=false;
-
-        lenient().when(dockerConfig.getUseDaemon()).thenReturn(USE_DAEMON);
-        lenient().when(dockerConfig.getDockerClient()).thenReturn(dockerClient);        
-        lenient().when(factory.getDockerConfig()).thenReturn(dockerConfig);
-
-        lenient().doNothing().when(startCmd).exec();
-        lenient().when(dockerClient.startContainerCmd(any())).thenReturn(startCmd);
-
-        lenient().when(logCmd.withFollowStream(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withStdOut(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withStdErr(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withTimestamps(any())).thenReturn(logCmd);
-        lenient().when(logCmd.exec(any())).thenReturn(null);
-        lenient().when(dockerClient.logContainerCmd(any())).thenReturn(logCmd);
-
-        lenient().when(waitCmd.exec(any())).thenReturn(waitResult);
-        lenient().when(waitResult.awaitStatusCode()).thenReturn(CONTAINER_RC);
-        lenient().when(dockerClient.waitContainerCmd(any())).thenReturn(waitCmd);
-
-        lenient().when(logConfig.getLogLevel()).thenReturn(LOG_LEVEL);
-        lenient().when(factory.getLogConfig()).thenReturn(logConfig);
-
-        lenient().when(builder.getUserId()).thenReturn(USER_ID);
-        lenient().when(builder.getGroupId()).thenReturn(GROUP_ID);
-        lenient().when(builder.getRunImages(any())).thenReturn(Stream.of(new ImageReference("runimage1"), new ImageReference("runimage2")).collect(Collectors.toList()).toArray(new ImageReference[]{}));
-        lenient().when(factory.getBuilderImage()).thenReturn(builder);
-
-        lenient().when(factory.getPlatformLevel()).thenReturn(new Version(PLATFORM_LEVEL));
-
-        lenient().when(factory.getContainerForPhase(argsCaptor.capture(), any())).thenReturn(CONTAINER_ID);
-
-        lenient().when(factory.getOutputImage()).thenReturn(new ImageReference(OUTPUT_IMAGE));
+    void test12OnwardsRun() {
+        lenient().when(factory.getPlatformLevel()).thenReturn(new Version("0.12"));
 
         Extender e = new Extender(factory, "run");
 
@@ -266,19 +163,16 @@ public class ExtenderTest {
 
         String[] args = argsCaptor.getValue();
         assertNotNull(args);
-        //verify 1st & last elements
         assertEquals("/cnb/lifecycle/extender", args[0]);
         assertNotEquals(args[args.length-1], OUTPUT_IMAGE);
 
         List<String> argList = Arrays.asList(args);
-        //verify kind not present in pre12
         assertTrue(argList.contains("-kind"));
         assertEquals("run", argList.get(argList.indexOf("-kind")+1));
-        //verify log as expected
         assertTrue(argList.contains(LOG_LEVEL));
 
         verify(logCmd).withTimestamps(true);
         verify(dockerClient).logContainerCmd(CONTAINER_ID);
-        verify(factory).getContainerForPhase(any(String[].class), eq(0)); //extender always runs as root
+        verify(factory).getContainerForPhase(any(String[].class), eq(0));
     }    
 }

--- a/client/src/test/java/dev/snowdrop/buildpack/lifecycle/phases/RestorerTest.java
+++ b/client/src/test/java/dev/snowdrop/buildpack/lifecycle/phases/RestorerTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -43,32 +44,31 @@ import dev.snowdrop.buildpack.lifecycle.Version;
 @ExtendWith(MockitoExtension.class)
 public class RestorerTest {
 
+    private static final String LOG_LEVEL = "debug";
+    private static final String CONTAINER_ID = "999";
+    private static final int CONTAINER_RC = 99;
+    private static final int USER_ID = 77;
+    private static final int GROUP_ID = 88;
+    private static final String OUTPUT_IMAGE = "stiletto";
+    private static final boolean USE_DAEMON = false;
+
     @Captor
     ArgumentCaptor<String[]> argsCaptor;
 
-    @Test
-    void testPre10(@Mock LifecyclePhaseFactory factory, 
-                  @Mock BuilderImage builder, 
-                  @Mock BuilderImage origBuilder,
-                  @Mock LogConfig logConfig, 
-                  @Mock DockerConfig dockerConfig, 
-                  @Mock DockerClient dockerClient,
-                  @Mock StartContainerCmd startCmd,
-                  @Mock LogContainerCmd logCmd,
-                  @Mock WaitContainerCmd waitCmd,
-                  @Mock WaitContainerResultCallback waitResult,
-                  @Mock Logger logger
-                  ) {
-        
-        String  PLATFORM_LEVEL="0.9";
-        String  LOG_LEVEL="debug";
-        String  CONTAINER_ID="999";
-        int     CONTAINER_RC=99;
-        int     USER_ID=77;
-        int     GROUP_ID=88;
-        String  OUTPUT_IMAGE="stiletto";
-        boolean USE_DAEMON=false;
+    @Mock LifecyclePhaseFactory factory;
+    @Mock BuilderImage builder;
+    @Mock BuilderImage origBuilder;
+    @Mock LogConfig logConfig;
+    @Mock DockerConfig dockerConfig;
+    @Mock DockerClient dockerClient;
+    @Mock StartContainerCmd startCmd;
+    @Mock LogContainerCmd logCmd;
+    @Mock WaitContainerCmd waitCmd;
+    @Mock WaitContainerResultCallback waitResult;
+    @Mock Logger logger;
 
+    @BeforeEach
+    void setUp() {
         lenient().when(dockerConfig.getUseDaemon()).thenReturn(USE_DAEMON);
         lenient().when(dockerConfig.getDockerClient()).thenReturn(dockerClient);        
         lenient().when(factory.getDockerConfig()).thenReturn(dockerConfig);
@@ -97,15 +97,17 @@ public class RestorerTest {
 
         lenient().when(origBuilder.getImage()).thenReturn(new ImageReference("fish"));
 
-        lenient().when(factory.getPlatformLevel()).thenReturn(new Version(PLATFORM_LEVEL));
-
         lenient().when(factory.getContainerForPhase(argsCaptor.capture(), any())).thenReturn(CONTAINER_ID);
 
         lenient().when(factory.getOutputImage()).thenReturn(new ImageReference(OUTPUT_IMAGE));
+    }
+
+    @Test
+    void testPre10() {
+        lenient().when(factory.getPlatformLevel()).thenReturn(new Version("0.9"));
 
         try (MockedStatic<? extends ContainerUtils> containerUtils = mockStatic(ContainerUtils.class)) {
-            Restorer r = new Restorer(factory,origBuilder);
-
+            Restorer r = new Restorer(factory, origBuilder);
             containerUtils.when(() -> ContainerUtils.getFileFromContainer(eq(dockerClient), any(), any())).thenReturn("EmptyTOML".getBytes());
 
             ContainerStatus cs = r.runPhase(logger, true);
@@ -113,24 +115,17 @@ public class RestorerTest {
             assertNotNull(cs);
             assertEquals(CONTAINER_ID, cs.getContainerId());
             assertEquals(CONTAINER_RC, cs.getRc());
-
             assertEquals("EmptyTOML", new String(r.getAnalyzedToml()));
         }
 
         String[] args = argsCaptor.getValue();
         assertNotNull(args);
-        //verify 1st & last elements
         assertEquals("/cnb/lifecycle/restorer", args[0]);
         assertNotEquals(args[args.length-1], OUTPUT_IMAGE);
 
         List<String> argList = Arrays.asList(args);
-        //verify build image not present in pre 0.10
         assertFalse(argList.contains("-build-image"));
-
-        //verify daemon is not set pre 0.12
         assertFalse(argList.contains("-daemon"));
-
-        //verify log as expected
         assertTrue(argList.contains(LOG_LEVEL));
 
         verify(logCmd).withTimestamps(true);
@@ -139,67 +134,12 @@ public class RestorerTest {
     }
 
     @Test
-    void testPost10Pre12NoXtns(@Mock LifecyclePhaseFactory factory, 
-                  @Mock BuilderImage builder, 
-                  @Mock BuilderImage origBuilder,
-                  @Mock LogConfig logConfig, 
-                  @Mock DockerConfig dockerConfig, 
-                  @Mock DockerClient dockerClient,
-                  @Mock StartContainerCmd startCmd,
-                  @Mock LogContainerCmd logCmd,
-                  @Mock WaitContainerCmd waitCmd,
-                  @Mock WaitContainerResultCallback waitResult,
-                  @Mock Logger logger
-                  ) {
-        
-        String  PLATFORM_LEVEL="0.10";
-        String  LOG_LEVEL="debug";
-        String  CONTAINER_ID="999";
-        int     CONTAINER_RC=99;
-        int     USER_ID=77;
-        int     GROUP_ID=88;
-        String  OUTPUT_IMAGE="stiletto";
-        boolean USE_DAEMON=false;
-        boolean HAS_EXTENSIONS=false;
-
-        lenient().when(dockerConfig.getUseDaemon()).thenReturn(USE_DAEMON);
-        lenient().when(dockerConfig.getDockerClient()).thenReturn(dockerClient);        
-        lenient().when(factory.getDockerConfig()).thenReturn(dockerConfig);
-
-        lenient().doNothing().when(startCmd).exec();
-        lenient().when(dockerClient.startContainerCmd(any())).thenReturn(startCmd);
-
-        lenient().when(logCmd.withFollowStream(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withStdOut(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withStdErr(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withTimestamps(any())).thenReturn(logCmd);
-        lenient().when(logCmd.exec(any())).thenReturn(null);
-        lenient().when(dockerClient.logContainerCmd(any())).thenReturn(logCmd);
-
-        lenient().when(waitCmd.exec(any())).thenReturn(waitResult);
-        lenient().when(waitResult.awaitStatusCode()).thenReturn(CONTAINER_RC);
-        lenient().when(dockerClient.waitContainerCmd(any())).thenReturn(waitCmd);
-
-        lenient().when(logConfig.getLogLevel()).thenReturn(LOG_LEVEL);
-        lenient().when(factory.getLogConfig()).thenReturn(logConfig);
-
-        lenient().when(builder.getUserId()).thenReturn(USER_ID);
-        lenient().when(builder.getGroupId()).thenReturn(GROUP_ID);
-        lenient().when(builder.getRunImages(any())).thenReturn(Stream.of(new ImageReference("runimage1"), new ImageReference("runimage2")).collect(Collectors.toList()).toArray(new ImageReference[]{}));
-        lenient().when(builder.hasExtensions()).thenReturn(HAS_EXTENSIONS);
-        lenient().when(factory.getBuilderImage()).thenReturn(builder);
-
-        lenient().when(origBuilder.getImage()).thenReturn(new ImageReference("fish"));
-
-        lenient().when(factory.getPlatformLevel()).thenReturn(new Version(PLATFORM_LEVEL));
-
-        lenient().when(factory.getContainerForPhase(argsCaptor.capture(), any())).thenReturn(CONTAINER_ID);
-
-        lenient().when(factory.getOutputImage()).thenReturn(new ImageReference(OUTPUT_IMAGE));
+    void testPost10Pre12NoXtns() {
+        lenient().when(builder.hasExtensions()).thenReturn(false);
+        lenient().when(factory.getPlatformLevel()).thenReturn(new Version("0.10"));
 
         try (MockedStatic<? extends ContainerUtils> containerUtils = mockStatic(ContainerUtils.class)) {
-            Restorer r = new Restorer(factory,origBuilder);
-
+            Restorer r = new Restorer(factory, origBuilder);
             containerUtils.when(() -> ContainerUtils.getFileFromContainer(eq(dockerClient), any(), any())).thenReturn("EmptyTOML".getBytes());
 
             ContainerStatus cs = r.runPhase(logger, true);
@@ -207,93 +147,31 @@ public class RestorerTest {
             assertNotNull(cs);
             assertEquals(CONTAINER_ID, cs.getContainerId());
             assertEquals(CONTAINER_RC, cs.getRc());
-
             assertEquals("EmptyTOML", new String(r.getAnalyzedToml()));
         }
 
         String[] args = argsCaptor.getValue();
         assertNotNull(args);
-        //verify 1st & last elements
         assertEquals("/cnb/lifecycle/restorer", args[0]);
         assertNotEquals(args[args.length-1], OUTPUT_IMAGE);
 
         List<String> argList = Arrays.asList(args);
-        //verify build image not present in 0.12 without xtns
         assertFalse(argList.contains("-build-image"));
-
-        //verify daemon is not set 0.12 when use daemon false
         assertFalse(argList.contains("-daemon"));
-
-        //verify log as expected
         assertTrue(argList.contains(LOG_LEVEL));
 
         verify(logCmd).withTimestamps(true);
         verify(dockerClient).logContainerCmd(CONTAINER_ID);
         verify(factory).getContainerForPhase(any(String[].class), eq(USER_ID));
-    }    
+    }
 
     @Test
-    void testPost10Pre12Xtns(@Mock LifecyclePhaseFactory factory, 
-                  @Mock BuilderImage builder, 
-                  @Mock BuilderImage origBuilder,
-                  @Mock LogConfig logConfig, 
-                  @Mock DockerConfig dockerConfig, 
-                  @Mock DockerClient dockerClient,
-                  @Mock StartContainerCmd startCmd,
-                  @Mock LogContainerCmd logCmd,
-                  @Mock WaitContainerCmd waitCmd,
-                  @Mock WaitContainerResultCallback waitResult,
-                  @Mock Logger logger
-                  ) {
-        
-        String  PLATFORM_LEVEL="0.10";
-        String  LOG_LEVEL="debug";
-        String  CONTAINER_ID="999";
-        int     CONTAINER_RC=99;
-        int     USER_ID=77;
-        int     GROUP_ID=88;
-        String  OUTPUT_IMAGE="stiletto";
-        boolean USE_DAEMON=false;
-        boolean HAS_EXTENSIONS=true;
-
-        lenient().when(dockerConfig.getUseDaemon()).thenReturn(USE_DAEMON);
-        lenient().when(dockerConfig.getDockerClient()).thenReturn(dockerClient);        
-        lenient().when(factory.getDockerConfig()).thenReturn(dockerConfig);
-
-        lenient().doNothing().when(startCmd).exec();
-        lenient().when(dockerClient.startContainerCmd(any())).thenReturn(startCmd);
-
-        lenient().when(logCmd.withFollowStream(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withStdOut(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withStdErr(any())).thenReturn(logCmd);
-        lenient().when(logCmd.withTimestamps(any())).thenReturn(logCmd);
-        lenient().when(logCmd.exec(any())).thenReturn(null);
-        lenient().when(dockerClient.logContainerCmd(any())).thenReturn(logCmd);
-
-        lenient().when(waitCmd.exec(any())).thenReturn(waitResult);
-        lenient().when(waitResult.awaitStatusCode()).thenReturn(CONTAINER_RC);
-        lenient().when(dockerClient.waitContainerCmd(any())).thenReturn(waitCmd);
-
-        lenient().when(logConfig.getLogLevel()).thenReturn(LOG_LEVEL);
-        lenient().when(factory.getLogConfig()).thenReturn(logConfig);
-
-        lenient().when(builder.getUserId()).thenReturn(USER_ID);
-        lenient().when(builder.getGroupId()).thenReturn(GROUP_ID);
-        lenient().when(builder.getRunImages(any())).thenReturn(Stream.of(new ImageReference("runimage1"), new ImageReference("runimage2")).collect(Collectors.toList()).toArray(new ImageReference[]{}));
-        lenient().when(builder.hasExtensions()).thenReturn(HAS_EXTENSIONS);
-        lenient().when(factory.getBuilderImage()).thenReturn(builder);
-
-        lenient().when(origBuilder.getImage()).thenReturn(new ImageReference("fish"));
-
-        lenient().when(factory.getPlatformLevel()).thenReturn(new Version(PLATFORM_LEVEL));
-
-        lenient().when(factory.getContainerForPhase(argsCaptor.capture(), any())).thenReturn(CONTAINER_ID);
-
-        lenient().when(factory.getOutputImage()).thenReturn(new ImageReference(OUTPUT_IMAGE));
+    void testPost10Pre12Xtns() {
+        lenient().when(builder.hasExtensions()).thenReturn(true);
+        lenient().when(factory.getPlatformLevel()).thenReturn(new Version("0.10"));
 
         try (MockedStatic<? extends ContainerUtils> containerUtils = mockStatic(ContainerUtils.class)) {
-            Restorer r = new Restorer(factory,origBuilder);
-
+            Restorer r = new Restorer(factory, origBuilder);
             containerUtils.when(() -> ContainerUtils.getFileFromContainer(eq(dockerClient), any(), any())).thenReturn("EmptyTOML".getBytes());
 
             ContainerStatus cs = r.runPhase(logger, true);
@@ -301,29 +179,55 @@ public class RestorerTest {
             assertNotNull(cs);
             assertEquals(CONTAINER_ID, cs.getContainerId());
             assertEquals(CONTAINER_RC, cs.getRc());
-
             assertEquals("EmptyTOML", new String(r.getAnalyzedToml()));
         }
 
         String[] args = argsCaptor.getValue();
         assertNotNull(args);
-        //verify 1st & last elements
         assertEquals("/cnb/lifecycle/restorer", args[0]);
         assertNotEquals(args[args.length-1], OUTPUT_IMAGE);
 
         List<String> argList = Arrays.asList(args);
-        //verify build image present in for 0.12 with xtns
         assertTrue(argList.contains("-build-image"));
-
-        //verify daemon is not set 0.12 when use daemon false
         assertFalse(argList.contains("-daemon"));
-
-        //verify log as expected
         assertTrue(argList.contains(LOG_LEVEL));
 
         verify(logCmd).withTimestamps(true);
         verify(dockerClient).logContainerCmd(CONTAINER_ID);
         verify(factory).getContainerForPhase(any(String[].class), eq(USER_ID));
-    }      
- 
+    }
+
+    @Test
+    void testPost14() {
+        lenient().when(builder.hasExtensions()).thenReturn(false);
+        lenient().when(factory.getPlatformLevel()).thenReturn(new Version("0.14"));
+
+        try (MockedStatic<? extends ContainerUtils> containerUtils = mockStatic(ContainerUtils.class)) {
+            Restorer r = new Restorer(factory, origBuilder);
+            containerUtils.when(() -> ContainerUtils.getFileFromContainer(eq(dockerClient), any(), any())).thenReturn("EmptyTOML".getBytes());
+
+            ContainerStatus cs = r.runPhase(logger, true);
+
+            assertNotNull(cs);
+            assertEquals(CONTAINER_ID, cs.getContainerId());
+            assertEquals(CONTAINER_RC, cs.getRc());
+            assertEquals("EmptyTOML", new String(r.getAnalyzedToml()));
+        }
+
+        String[] args = argsCaptor.getValue();
+        assertNotNull(args);
+        assertEquals("/cnb/lifecycle/restorer", args[0]);
+        assertNotEquals(args[args.length-1], OUTPUT_IMAGE);
+
+        List<String> argList = Arrays.asList(args);
+        assertFalse(argList.contains("-build-image"));
+        assertFalse(argList.contains("-daemon"));
+        assertTrue(argList.contains("-run"));
+        assertTrue(argList.contains("/cnb/run.toml"));
+        assertTrue(argList.contains(LOG_LEVEL));
+
+        verify(logCmd).withTimestamps(true);
+        verify(dockerClient).logContainerCmd(CONTAINER_ID);
+        verify(factory).getContainerForPhase(any(String[].class), eq(USER_ID));
+    }
 }

--- a/client/src/test/java/dev/snowdrop/buildpack/utils/FilePermissionsTest.java
+++ b/client/src/test/java/dev/snowdrop/buildpack/utils/FilePermissionsTest.java
@@ -1,0 +1,53 @@
+package dev.snowdrop.buildpack.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class FilePermissionsTest {
+
+    @Test
+    void testGetPermissions(@TempDir Path tempDir) throws IOException {
+        Path tempFile = Files.createTempFile(tempDir, "test-perms", ".tmp");
+        File file = tempFile.toFile();
+
+        FilePermissions filePermissions = new FilePermissions();
+        Integer mode = filePermissions.getPermissions(file);
+        assertNotNull(mode);
+
+        if (tempFile.getFileSystem().supportedFileAttributeViews().contains("posix")) {
+            // Test POSIX conversion
+            Set<PosixFilePermission> permissions = new HashSet<>();
+            permissions.add(PosixFilePermission.OWNER_READ);
+            permissions.add(PosixFilePermission.OWNER_WRITE);
+            permissions.add(PosixFilePermission.OWNER_EXECUTE);
+            Files.setPosixFilePermissions(tempFile, permissions);
+
+            Integer posixMode = filePermissions.getPermissions(file);
+            // 0400 + 0200 + 0100 = 0700 (octal) -> 448 in decimal
+            assertEquals(0700, posixMode);
+        } else {
+            // Test fallback behavior
+            file.setReadable(true);
+            file.setWritable(true);
+            file.setExecutable(true);
+
+            Integer fallbackMode = filePermissions.getPermissions(file);
+            // Owner and Group read/write/exec:
+            // Owner: 0400 + 0200 + 0100 = 0700
+            // Group: 040 + 020 + 010 = 070
+            // Total: 0770 -> 504 in decimal
+            assertEquals(0770, fallbackMode);
+        }
+    }
+}

--- a/client/src/test/java/dev/snowdrop/buildpack/utils/JsonUtilsTest.java
+++ b/client/src/test/java/dev/snowdrop/buildpack/utils/JsonUtilsTest.java
@@ -28,8 +28,16 @@ public class JsonUtilsTest {
             String word = JsonUtils.getValue(root, "aWord");
             assertEquals("wibble", word);
 
+            // Test with leading slash
+            String wordWithSlash = JsonUtils.getValue(root, "/aWord");
+            assertEquals("wibble", wordWithSlash);
+
             String nestedWord = JsonUtils.getValue(root, "models/patent/color");
             assertEquals("red",nestedWord);
+
+            // Test nested with leading slash
+            String nestedWordWithSlash = JsonUtils.getValue(root, "/models/patent/color");
+            assertEquals("red", nestedWordWithSlash);
 
             String number = JsonUtils.getValue(root, "aNumber");
             assertEquals("1337", number);
@@ -37,6 +45,11 @@ public class JsonUtilsTest {
             List<String> wordList = JsonUtils.getArray(root, "heels");
             assertNotNull(wordList);
             assertEquals(3, wordList.size());
+
+            // Test array with leading slash
+            List<String> wordListWithSlash = JsonUtils.getArray(root, "/heels");
+            assertNotNull(wordListWithSlash);
+            assertEquals(3, wordListWithSlash.size());
 
             List<String> numberList = JsonUtils.getArray(root, "sizes");
             assertNotNull(numberList);

--- a/client/src/test/java/dev/snowdrop/buildpack/utils/LifecycleMetadataTest.java
+++ b/client/src/test/java/dev/snowdrop/buildpack/utils/LifecycleMetadataTest.java
@@ -1,0 +1,80 @@
+package dev.snowdrop.buildpack.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import com.github.dockerjava.api.DockerClient;
+
+import dev.snowdrop.buildpack.BuildpackException;
+import dev.snowdrop.buildpack.config.DockerConfig;
+import dev.snowdrop.buildpack.config.ImageReference;
+import dev.snowdrop.buildpack.docker.ImageUtils;
+import dev.snowdrop.buildpack.docker.ImageUtils.ImageInfo;
+
+public class LifecycleMetadataTest {
+
+    @Test
+    void testLifecycleMetadataParsingSuccess() throws BuildpackException {
+        DockerConfig dc = mock(DockerConfig.class);
+        DockerClient dockerClient = mock(DockerClient.class);
+        when(dc.getDockerClient()).thenReturn(dockerClient);
+
+        ImageReference lifecycleImage = new ImageReference("lifecycle-image");
+
+        ImageInfo mockImageInfo = new ImageInfo();
+        mockImageInfo.labels = new HashMap<>();
+        mockImageInfo.labels.put("io.buildpacks.lifecycle.apis", 
+            "{\"platform\":{\"supported\":[\"0.7\",\"0.9\",\"0.10\"]},\"buildpack\":{\"supported\":[\"0.6\",\"0.7\"]}}");
+
+        try (MockedStatic<ImageUtils> imageUtils = mockStatic(ImageUtils.class)) {
+            imageUtils.when(() -> ImageUtils.inspectImage(any(), any())).thenReturn(mockImageInfo);
+            imageUtils.when(() -> ImageUtils.pullImages(any(), any())).thenAnswer(invocation -> null);
+
+            LifecycleMetadata metadata = new LifecycleMetadata(dc, lifecycleImage);
+
+            assertNotNull(metadata.getSupportedPlatformLevels());
+            assertEquals(3, metadata.getSupportedPlatformLevels().size());
+            assertEquals("0.7", metadata.getSupportedPlatformLevels().get(0));
+            assertEquals("0.9", metadata.getSupportedPlatformLevels().get(1));
+            assertEquals("0.10", metadata.getSupportedPlatformLevels().get(2));
+
+            assertNotNull(metadata.getSupportedBuildpackLevels());
+            assertEquals(2, metadata.getSupportedBuildpackLevels().size());
+            assertEquals("0.6", metadata.getSupportedBuildpackLevels().get(0));
+            assertEquals("0.7", metadata.getSupportedBuildpackLevels().get(1));
+        }
+    }
+
+    @Test
+    void testLifecycleMetadataParsingFailure() {
+        DockerConfig dc = mock(DockerConfig.class);
+        DockerClient dockerClient = mock(DockerClient.class);
+        when(dc.getDockerClient()).thenReturn(dockerClient);
+
+        ImageReference lifecycleImage = new ImageReference("lifecycle-image");
+
+        ImageInfo mockImageInfo = new ImageInfo();
+        mockImageInfo.labels = new HashMap<>();
+        // Bad JSON
+        mockImageInfo.labels.put("io.buildpacks.lifecycle.apis", "{invalid-json}");
+
+        try (MockedStatic<ImageUtils> imageUtils = mockStatic(ImageUtils.class)) {
+            imageUtils.when(() -> ImageUtils.inspectImage(any(), any())).thenReturn(mockImageInfo);
+            imageUtils.when(() -> ImageUtils.pullImages(any(), any())).thenAnswer(invocation -> null);
+
+            assertThrows(BuildpackException.class, () -> {
+                new LifecycleMetadata(dc, lifecycleImage);
+            });
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <version.maven-enforcer-plugin>1.3.1</version.maven-enforcer-plugin>
     <version.maven-javadoc-plugin>3.7.0</version.maven-javadoc-plugin>
     <version.maven-source-plugin>3.3.1</version.maven-source-plugin>
-    <version.nexus-staging-maven-plugin>1.6.13</version.nexus-staging-maven-plugin>	  
+    <version.central-publishing-maven-plugin>0.7.0</version.central-publishing-maven-plugin>
   </properties>
 
   <modules>
@@ -305,17 +305,16 @@
              </configuration>
            </plugin>
            <plugin>
-             <groupId>org.sonatype.plugins</groupId>
-             <artifactId>nexus-staging-maven-plugin</artifactId>
-             <version>${version.nexus-staging-maven-plugin}</version>
+             <groupId>org.sonatype.central</groupId>
+             <artifactId>central-publishing-maven-plugin</artifactId>
+             <version>${version.central-publishing-maven-plugin}</version>
              <extensions>true</extensions>
              <configuration>
-               <serverId>oss-sonatype-staging</serverId>
-               <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-               <autoReleaseAfterClose>true</autoReleaseAfterClose>
-               <stagingProgressTimeoutMinutes>60</stagingProgressTimeoutMinutes>
+               <publishingServerId>central</publishingServerId>
+               <autoPublish>true</autoPublish>
+               <waitUntil>published</waitUntil>
              </configuration>
-           </plugin>		
+           </plugin>
         </plugins>
       </build>
     </profile>

--- a/samples/testcases/RunRegistryTest.java
+++ b/samples/testcases/RunRegistryTest.java
@@ -9,7 +9,7 @@ import java.io.File;
 import dev.snowdrop.buildpack.*;
 import dev.snowdrop.buildpack.config.*;
 import dev.snowdrop.buildpack.docker.*;
-import dev.snowdrop.buildpack.utils.OperatingSytem;
+import dev.snowdrop.buildpack.utils.OperatingSystem;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.HashMap;
@@ -87,8 +87,8 @@ public class RunRegistryTest {
          
       int exitCode = 0;
 
-      OperatingSytem os = OperatingSytem.getOperationSystem();
-      if(os != OperatingSytem.WIN) {
+      OperatingSystem os = OperatingSystem.getOperatingSystem();
+      if(os != OperatingSystem.WIN) {
           System.out.println("Building "+outputImage+" using "+authInfo.size()+" credentials, with builder "+builderImage);
           exitCode = BuildConfig.builder()
                            .withBuilderImage(new ImageReference(builderImage))

--- a/samples/testcases/RunTest.java
+++ b/samples/testcases/RunTest.java
@@ -9,7 +9,7 @@ import java.io.File;
 import dev.snowdrop.buildpack.*;
 import dev.snowdrop.buildpack.config.*;
 import dev.snowdrop.buildpack.docker.*;
-import dev.snowdrop.buildpack.utils.OperatingSytem;
+import dev.snowdrop.buildpack.utils.OperatingSystem;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.Optional;
@@ -71,8 +71,8 @@ public class RunTest {
 
       int exitCode = 0;
 
-      OperatingSytem os = OperatingSytem.getOperationSystem();
-      if(os != OperatingSytem.WIN) {
+      OperatingSystem os = OperatingSystem.getOperatingSystem();
+      if(os != OperatingSystem.WIN) {
           exitCode = BuildConfig.builder()
                            .withBuilderImage(new ImageReference(builderImage))
                            .withOutputImage(new ImageReference(outputImage))


### PR DESCRIPTION
Includes: 
 - removal of macos13 runner from tests, as has been removed by github. 
 - ossrh publishing migration
 - add support for platform 0.13 / 0.14
 - bugfixes
   - groupId was set from userid param
   - minor string processing fixes
   - typo corrections for OperatingSystem
   - image pull timeout now reports correctly
   - additional test cases & mock cleanup